### PR TITLE
Ignore the runs dir where tb logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.onnx
 .coverage
 docs/_build
+runs/**


### PR DESCRIPTION
Tensorboard logs to `runs/` by default. Ignore that directory so we can continue using the default arguments for the writer.