### PR TITLE
Add box-2d to requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ sphinx-rtd-theme = "^1.0.0"
 black = "^22.1.0"
 gsutil = "=4.66"
 isort = "^5.10.1"
-gym = {extras = ["atari", "classic_control"], version = "^0.22.0"}
+gym = {extras = ["atari", "classic_control", "box2d"], version = "^0.22.0"}
 box2d = "2.3.10"
 pygame = "2.1.0"
 


### PR DESCRIPTION
As the title says this PR adds box2D envs to the requirements for this repo, since we use box2D envs in our tests. At the moment even though we have box2D in the list of requirements, we're unable to train in box2D environments and get an error. This solves that.