### PR TITLE
Create release flow on-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           dist/*
           LICENSE-*
 
-    - name: Publish Packages to TestPyPi
+    - name: Publish Packages to PyPi
       env:
         PDM_PUBLISH_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 


### PR DESCRIPTION
This should release to PyPi and GHA when tagging a release on main.