### PR TITLE
Ensure `latest` tag has proper contents and commit

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -41,7 +41,7 @@ jobs:
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git tag -a "latest" -m "Setting latest release to ${{ github.sha }}" -f
-          git push origin latest
+          git push origin --force-with-lease latest
 
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -41,7 +41,7 @@ jobs:
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git tag -a "latest" -m "Setting latest release to ${{ github.sha }}"
-          git push origin "latest"
+          git push origin --force-with-lease "latest"
 
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -37,11 +37,12 @@ jobs:
       - name: Fetch tags
         run: git fetch --prune --unshallow --tags
 
-      # - run: |
-      #     git config user.name "${GITHUB_ACTOR}"
-      #     git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-      #     git tag -a "latest" -m "Setting latest release to ${{ github.sha }}" -f
-      #     git push origin --force-with-lease latest
+      - name: Update tag
+        uses: richardsimko/update-tag@v1
+        with:
+          tag_name: latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -84,6 +84,7 @@ jobs:
           prerelease: true
           target_commitish: ${{ github.sha }}
           tag_name: "latest"
+          name: "Nightly release"
           files: |
             dist/*
             LICENSE-*

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -37,11 +37,11 @@ jobs:
       - name: Fetch tags
         run: git fetch --prune --unshallow --tags
 
-      - run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git tag -a "latest" -m "Setting latest release to ${{ github.sha }}" -f
-          git push origin --force-with-lease latest
+      # - run: |
+      #     git config user.name "${GITHUB_ACTOR}"
+      #     git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      #     git tag -a "latest" -m "Setting latest release to ${{ github.sha }}" -f
+      #     git push origin --force-with-lease latest
 
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM
@@ -73,6 +73,7 @@ jobs:
         with:
           body: ${{ steps.github_release.outputs.changelog }}
           prerelease: true
+          target_commitish: ${{ github.sha }}
           tag_name: "latest"
           files: |
             dist/*

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -40,8 +40,8 @@ jobs:
       - run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git tag -a "latest" -m "Setting latest release to ${{ github.sha }}"
-          git push origin --force-with-lease "latest"
+          git tag -a "latest" -m "Setting latest release to ${{ github.sha }}" -f
+          git push origin latest
 
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -37,6 +37,11 @@ jobs:
       - name: Fetch tags
         run: git fetch --prune --unshallow --tags
 
+      - uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: "latest"
+          message: 'Tagging latest ${{ github.ref }}'
+
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM
         with:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -37,10 +37,11 @@ jobs:
       - name: Fetch tags
         run: git fetch --prune --unshallow --tags
 
-      - uses: actions-ecosystem/action-push-tag@v1
-        with:
-          tag: "latest"
-          message: 'Tagging latest ${{ github.ref }}'
+      - run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git tag -a "latest" -m "Setting latest release to ${{ github.sha }}"
+          git push origin "latest"
 
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -69,6 +69,14 @@ jobs:
           configuration: ".github/release-action-config.json"
           toTag: ${{ github.ref }}
 
+      - name: Delete old release assets
+        uses: mknejp/delete-release-assets@v1
+        with:
+          token: ${{ github.token }}
+          tag: latest
+
+          assets: 'emote*'
+
       - name: Create Release
         uses: mikepenz/action-gh-release@v0.2.0-a03 #softprops/action-gh-release
         with:


### PR DESCRIPTION
This ensures the nightly release points to the proper tag and contents. Previously they'd keep old files and the sha wasn't getting updated.

I noticed it's containing the wrong changelog; I think that's an upstream bug that'll resolve when we release the next version.