### PR TITLE
allow specifying multiple dependencies for pdm-plugin-torch

### DIFF
--- a/plugins/pdm-plugin-torch/src/pdm_plugin_torch/config.py
+++ b/plugins/pdm-plugin-torch/src/pdm_plugin_torch/config.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 
 @dataclass(frozen=True)
 class Configuration:
-    torch_version: str
+    dependencies: list[str]
     enable_cpu: bool = False
 
     enable_cuda: bool = False

--- a/plugins/pdm-plugin-torch/src/pdm_plugin_torch/main.py
+++ b/plugins/pdm-plugin-torch/src/pdm_plugin_torch/main.py
@@ -312,8 +312,11 @@ class TorchCommand(BaseCommand):
 
         spec_for_version = lockfile[options.api]
         (source, local_version) = resolves[options.api]
-        local_req = f"{plugin_config.torch_version}{local_version}"
-        req = parse_requirement(local_req, False)
+        reqs = [
+            parse_requirement(f"{req}{local_version}", False)
+            for req in plugin_config.dependencies
+        ]
+
         do_sync(
             project,
             raw_sources=[
@@ -323,7 +326,7 @@ class TorchCommand(BaseCommand):
                     "type": "index",
                 }
             ],
-            requirements=[req],
+            requirements=reqs,
             lockfile=spec_for_version,
         )
 
@@ -351,9 +354,10 @@ class TorchCommand(BaseCommand):
 
         results = {}
         for (api, (url, local_version)) in plugin_config.variants.items():
-            local_req = f"{plugin_config.torch_version}{local_version}"
-
-            req = parse_requirement(local_req, False)
+            reqs = [
+                parse_requirement(f"{req}{local_version}", False)
+                for req in plugin_config.dependencies
+            ]
 
             results[api] = do_lock(
                 project,
@@ -364,7 +368,7 @@ class TorchCommand(BaseCommand):
                         "type": "index",
                     }
                 ],
-                requirements=[req],
+                requirements=reqs,
             )
 
         write_lockfile(project, plugin_config.lockfile, results)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,9 @@ name = "torch"
 respect-source-order = true
 
 [tool.pdm.plugins.torch]
-torch-version = "torch==1.10.2"
+dependencies = [
+   "torch==1.10.2"
+]
 lockfile = "torch.lock"
 enable-cpu = true
 


### PR DESCRIPTION
This allows emit to use the same plugin to pull in `torch` and `torchvision` together.