### PR TITLE
Optimize CI performance with preinstalls and dedicated CPU

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -10,6 +10,12 @@ RUN apt-get -y update && \
     apt-get -y install curl build-essential gcc git && \
     apt-get -y clean
 
+RUN mkdir -p /gcloud/ && \
+	curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-408.0.1-linux-x86_64.tar.gz && \
+	tar -xf google-cloud-cli-408.0.1-linux-x86_64.tar.gz -C /gcloud/ && \
+	/gcloud/google-cloud-sdk/install.sh --quiet --usage-reporting false && \
+	rm google-cloud-cli-408.0.1-linux-x86_64.tar.gz
+
 RUN pip install \
 	--no-cache-dir \
 	pdm==2.2.0

--- a/.buildkite/install-repo.sh
+++ b/.buildkite/install-repo.sh
@@ -1,5 +1,10 @@
 set -eo pipefail
 
+echo --- Setting up google-cloud-sdk
+
+if [ -f '/gcloud/google-cloud-sdk/path.bash.inc' ]; then . '/gcloud/google-cloud-sdk/path.bash.inc'; fi
+gcloud config set account monorepo-ci@embark-builds.iam.gserviceaccount.com
+
 echo --- Installing dependencies
 
 pdm install -d -G ci

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,46 +1,44 @@
-small: &small
-  agents:
-    cluster: builds-fi-2
-    queue: monorepo-ci
-    size: small
+plugin_base: &plugin_base
+    service-account-name: monorepo-ci
+    image: gcr.io/embark-shared/ml/ci-runner@sha256:ca727fde178e60353820416619201cb0302b8896ddeda412916e7aa802fb441d
+    default-secret-name: buildkite-k8s-plugin
+    always-pull: false
 
-large: &large
-  agents:
-    cluster: builds-fi-2
-    queue: monorepo-ci
-    size: large
-
-
-plugins: &plugins
+tiny: &tiny
   plugins:
   - EmbarkStudios/k8s#1.2.10:
-      service-account-name: monorepo-ci
-      image: gcr.io/embark-shared/ml/ci-runner@sha256:ca727fde178e60353820416619201cb0302b8896ddeda412916e7aa802fb441d
-      default-secret-name: buildkite-k8s-plugin
-      always-pull: false
+      << : *plugin_base
+      resources-limit-cpu: 3
+      resources-limit-memory: 10Gi
 
-small_container: &small_container
-  << : *small
-  << : *plugins
+small: &small
+  plugins:
+  - EmbarkStudios/k8s#1.2.10:
+      << : *plugin_base
+      resources-limit-cpu: 7
+      resources-limit-memory: 20Gi
 
-large_container: &large_container
-  << : *large
-  << : *plugins
+large: &large
+  plugins:
+  - EmbarkStudios/k8s#1.2.10:
+      << : *plugin_base
+      resources-limit-cpu: 14
+      resources-limit-memory: 35Gi
 
 steps:
   - group: ":passport_control: Validating PR"
     steps:
       - label: ":hourglass: Validating branch age"
         command: bash .buildkite/validate-branch-age.sh
-        << : *small
+        << : *tiny
 
       - label: ":straight_ruler: Checking line-endings"
         command: bash .buildkite/check-line-endings.sh
-        << : *small
+        << : *tiny
 
       - label: ":lock: Checking lockfile"
         command: bash .buildkite/validate-lockfile.sh
-        << : *small_container
+        << : *tiny
 
   - wait
 
@@ -48,26 +46,26 @@ steps:
     steps:
       - label: 📚 Publish docs
         command: bash .buildkite/publish-docs.sh
-        << : *small_container
+        << : *tiny
 
       - label: ":python-black: Validate black"
         command: bash .buildkite/run-black.sh
-        << : *small_container
+        << : *tiny
 
       - label: ":isort: Validate isort"
         command: bash .buildkite/run-isort.sh
-        << : *small_container
+        << : *tiny
 
       - label: ":bandit: Validate bandit"
         command: bash .buildkite/run-bandit.sh
-        << : *small_container
+        << : *tiny
 
       - label: ":pytest: Run tests"
         command: bash .buildkite/run-pytest.sh
-        << : *large_container
+        << : *large
 
   - wait
 
   - label: ":package: Validate packaging"
     command: bash .buildkite/run-package.sh
-    << : *small_container
+    << : *tiny

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,7 @@ plugin_base: &plugin_base
     image: gcr.io/embark-shared/ml/ci-runner@sha256:ca727fde178e60353820416619201cb0302b8896ddeda412916e7aa802fb441d
     default-secret-name: buildkite-k8s-plugin
     always-pull: false
+    use-agent-node-affinity: true
 
 agents: &agent
   cluster: builds-fi-2

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,11 @@ plugin_base: &plugin_base
     default-secret-name: buildkite-k8s-plugin
     always-pull: false
 
+agents:
+  cluster: builds-fi-2
+  queue: monorepo-ci
+  size: small
+
 tiny: &tiny
   plugins:
   - EmbarkStudios/k8s#1.2.10:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ plugins: &plugins
   plugins:
   - EmbarkStudios/k8s#1.2.10:
       service-account-name: monorepo-ci
-      image: gcr.io/embark-shared/ml/ci-runner@sha256:e239cfbf62573c273726e52f7579d489026dfc8610976925a8036a26a851f1d5
+      image: gcr.io/embark-shared/ml/ci-runner@sha256:ca727fde178e60353820416619201cb0302b8896ddeda412916e7aa802fb441d
       default-secret-name: buildkite-k8s-plugin
       always-pull: false
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,19 +4,23 @@ plugin_base: &plugin_base
     default-secret-name: buildkite-k8s-plugin
     always-pull: false
 
-agents:
+agents: &agent
   cluster: builds-fi-2
   queue: monorepo-ci
   size: small
 
 tiny: &tiny
+  agents: *agent
   plugins:
   - EmbarkStudios/k8s#1.2.10:
       << : *plugin_base
       resources-limit-cpu: 3
       resources-limit-memory: 10Gi
 
+  agents: *agent
+
 small: &small
+  agents: *agent
   plugins:
   - EmbarkStudios/k8s#1.2.10:
       << : *plugin_base
@@ -24,11 +28,14 @@ small: &small
       resources-limit-memory: 20Gi
 
 large: &large
+  agents: *agent
   plugins:
   - EmbarkStudios/k8s#1.2.10:
       << : *plugin_base
       resources-limit-cpu: 14
       resources-limit-memory: 35Gi
+
+
 
 steps:
   - group: ":passport_control: Validating PR"

--- a/.buildkite/publish-docs.sh
+++ b/.buildkite/publish-docs.sh
@@ -5,12 +5,6 @@ source .buildkite/install-repo.sh
 
 echo --- Initializing gcloud
 
-curl https://sdk.cloud.google.com > install.sh && \
-    bash install.sh --disable-prompts 2>&1 && \
-    /root/google-cloud-sdk/install.sh --path-update true --usage-reporting false --quiet
-
-if [ -f '/root/google-cloud-sdk/path.bash.inc' ]; then . '/root/google-cloud-sdk/path.bash.inc'; fi
-gcloud config set account monorepo-ci@embark-builds.iam.gserviceaccount.com
 
 echo --- Building docs
 pushd docs


### PR DESCRIPTION
Noticied when working on $OTHER_REPO that there's some wonkiness with how we install gcloud and setup our CI tasks that leads to subpar performance. This change should have very little impact on regular running but when the builds cluster is under heavy load we'll not degrade as heavily as we have in the past.

In practice we have ended up running on "any" resource available. I noticed this because we had crammed a bunch of pytest runners into a single available CPU slot, causing some 10-second checks to run for 10+ minutes.