### PR TITLE
allow None in cycle to disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bugfixes
 
 - Fix `FeatureAgentProxy.input_names` to use `input_key` when configured.
+- `Callback.cycle` can now be `None`
 
 ## [23.0.0] - 2023-03-03
 

--- a/emote/callback.py
+++ b/emote/callback.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import logging
 import warnings
@@ -177,7 +179,7 @@ class Callback(metaclass=CallbackMeta):
     The concept has been borrowed from Keras and FastAI.
     """
 
-    def __init__(self, cycle=0):
+    def __init__(self, cycle: int | None = None):
         super().__init__()
         self._order = 0
         self.cycle = cycle

--- a/emote/trainer.py
+++ b/emote/trainer.py
@@ -39,7 +39,9 @@ class Trainer:
         batch_size_key: str = "batch_size",
     ):
         self.callbacks = sorted(callbacks, key=lambda cb: cb._order)
-        self._cyclic_callbacks = [cb for cb in self.callbacks if cb.cycle > 0]
+        self._cyclic_callbacks = [
+            cb for cb in self.callbacks if cb.cycle is not None and cb.cycle > 0
+        ]
         self.dataloader = dataloader
         self.state = StateDict()
         self._batch_size_key = batch_size_key
@@ -58,7 +60,6 @@ class Trainer:
         self.state["bp_samples"] = 0
 
         try:
-
             for bp_step, batch in zip(count(1), self.dataloader):
                 self.state.update(batch)
                 self.state["bp_step"] = bp_step

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from emote.callback import Callback
+from emote.trainer import Trainer, TrainingShutdownException
+
+
+class DummyCallback(Callback):
+    def __init__(self, cycle: int | None = None):
+        super().__init__(cycle)
+        self.end_cycle_called = 0
+
+    def end_cycle(self):
+        self.end_cycle_called += 1
+
+
+class DummyLoader:
+    def __iter__(self):
+        for _ in range(3):
+            yield {"batch_size": 0}
+
+        raise TrainingShutdownException("end of data")
+
+
+@pytest.mark.parametrize("interval,expected", ((None, 0), (0, 0), (1, 3), (2, 1)))
+def test_callback_cycle_called_count(interval, expected):
+    callback = DummyCallback(interval)
+
+    Trainer([callback], DummyLoader()).train()
+
+    assert callback.end_cycle_called == expected


### PR DESCRIPTION
I think we talked about what cycle 0 means before @singhblom but I added a bug in the OnnxExporter by default to None instead of 0. And I think that is *more* correct as a value for "don't run". 
