### PR TITLE
refactor LoggingCallback to LoggingMixin

### DIFF
--- a/emote/__init__.py
+++ b/emote/__init__.py
@@ -4,7 +4,7 @@ Emote
 ========
 
 
-In order to do reinforcement learning we need to have two things: 
+In order to do reinforcement learning we need to have two things:
 A **learning protocol** that specifies which losses to use, which network
 architectures, which optimizers, and so forth. We also need some kind of
 **data collector** that interacts with the world and stores the experiences
@@ -18,14 +18,14 @@ by a Trainer.
 
 from . import nn, sac, utils
 from .callback import Callback
-from .callbacks import LoggingCallback, LossCallback
+from .callbacks import LoggingMixin, LossCallback
 from .trainer import Trainer, WeakReference
 
 
 __all__ = [
     "Callback",
     "LossCallback",
-    "LoggingCallback",
+    "LoggingMixin",
     "Trainer",
     "WeakReference",
     "sac",

--- a/emote/callbacks.py
+++ b/emote/callbacks.py
@@ -15,13 +15,14 @@ from .callback import Callback
 from .trainer import TrainingShutdownException
 
 
-class LoggingCallback(Callback):
-    """A Callback that accepts logging calls.
+class LoggingMixin:
+    """A Mixin that accepts logging calls.
 
-    Logged data is saved on this object and gets written
-    by a Logger callback. LoggingCallback therefore doesn't
-    care how the data is logged, it only provides a standard
-    interface for storing the data to be handled by a Logger."""
+    Logged data is saved on this object and gets written by a
+    Logger. This therefore doesn't care how the data is logged, it
+    only provides a standard interface for storing the data to be
+    handled by a Logger.
+    """
 
     def __init__(self, cycle: int = 0):
         super().__init__(cycle)
@@ -65,7 +66,7 @@ class LoggingCallback(Callback):
         super().load_state_dict(state_dict)
 
 
-class LossCallback(LoggingCallback):
+class LossCallback(LoggingMixin, Callback):
     """Losses are callbacks that implement a *loss function*."""
 
     def __init__(
@@ -130,7 +131,7 @@ class TensorboardLogger(Callback):
 
     def __init__(
         self,
-        callbacks: List[LoggingCallback],
+        callbacks: List[LoggingMixin],
         writer: SummaryWriter,
         log_interval: int,
         log_by_samples: bool = False,
@@ -143,52 +144,30 @@ class TensorboardLogger(Callback):
     def begin_training(self, *args, **kwargs):
         self._start_time = time.monotonic()
 
-    def log_scalars(self, step, suffix=None):
-        """Logs scalar logs adding optional suffix on the first level.
+    def end_cycle(self, bp_step, bp_samples):
+        suffix = "bp_step"
 
-        **Example:** If k='training/loss' and suffix='bp_step', k will be renamed to
-        'training_bp_step/loss'.
-        """
         for cb in self._cbs:
             for k, v in cb.scalar_logs.items():
                 if suffix:
                     k_split = k.split("/")
                     k_split[0] = k_split[0] + "_" + suffix
                     k = "/".join(k_split)
-                self._writer.add_scalar(k, v, step)
+                self._writer.add_scalar(k, v, bp_step)
 
-    def log_images(self, step, suffix=None):
-        """Logs images adding optional suffix on the first level.
-
-        **Example:** If k='training/loss' and suffix='bp_step', k will be renamed to
-        'training_bp_step/loss'.
-        """
-        for cb in self._cbs:
             for k, v in cb.image_logs.items():
                 if suffix:
                     k_split = k.split("/")
                     k_split[0] = k_split[0] + "_" + suffix
                     k = "/".join(k_split)
-                self._writer.add_image(k, v, step, dataformats="HWC")
+                self._writer.add_image(k, v, bp_step, dataformats="HWC")
 
-    def log_videos(self, step, suffix=None):
-        """Logs videos.
-
-        **Example:** If k='training/loss' and suffix='bp_step', k will be renamed to
-        'training_bp_step/loss'.
-        """
-        for cb in self._cbs:
             for k, (video_array, fps) in cb.video_logs.items():
                 if suffix:
                     k_split = k.split("/")
                     k_split[0] = k_split[0] + "_" + suffix
                     k = "/".join(k_split)
-                self._writer.add_video(k, video_array, step, fps=fps, walltime=None)
-
-    def end_cycle(self, bp_step, bp_samples):
-        self.log_scalars(bp_step, suffix="bp_step")
-        self.log_images(bp_step, suffix="bp_step")
-        self.log_videos(bp_step, suffix="bp_step")
+                self._writer.add_video(k, video_array, bp_step, fps=fps, walltime=None)
 
         time_since_start = time.monotonic() - self._start_time
         self._writer.add_scalar(
@@ -204,11 +183,11 @@ class TerminalLogger(Callback):
 
     def __init__(
         self,
-        callbacks: List[LoggingCallback],
+        callbacks: List[LoggingMixin],
         log_interval: int,
     ):
         super().__init__(cycle=log_interval)
-        self._cbs = callbacks
+        self._logs = callbacks
 
     def log_scalars(self, step, suffix=None):
         """Logs scalar logs adding optional suffix on the first level.
@@ -216,8 +195,8 @@ class TerminalLogger(Callback):
         **Example:** If k='training/loss' and suffix='bp_step', k will be renamed to
         'training_bp_step/loss'.
         """
-        for cb in self._cbs:
-            for k, v in cb.scalar_logs.items():
+        for log in self._logs:
+            for k, v in log.scalar_logs.items():
                 if suffix:
                     k_split = k.split("/")
                     k_split[0] = k_split[0] + "_" + suffix
@@ -366,7 +345,7 @@ class FinalLossTestCheck(Callback):
 class FinalRewardTestCheck(Callback):
     def __init__(
         self,
-        callback: LoggingCallback,
+        callback: LoggingMixin,
         cutoff: float,
         test_length: int,
     ):

--- a/emote/extra/onnx_exporter.py
+++ b/emote/extra/onnx_exporter.py
@@ -12,7 +12,8 @@ import torch
 
 from google.protobuf import text_format
 
-from emote.callbacks import LoggingCallback
+from emote.callback import Callback
+from emote.callbacks import LoggingMixin
 from emote.extra.crud_storage import CRUDStorage, StorageItem, StorageItemHandle
 from emote.proxies import AgentProxy
 from emote.utils.spaces import MDPSpace
@@ -57,7 +58,7 @@ def _save_protobuf(path, message, as_text: bool = False):
             f.write(message.SerializeToString())
 
 
-class OnnxExporter(LoggingCallback):
+class OnnxExporter(LoggingMixin, Callback):
     """Handles onnx exports of a ML policy.
 
     Call `export` whenever you want to save an onnx version of the

--- a/emote/extra/system_logger.py
+++ b/emote/extra/system_logger.py
@@ -6,10 +6,11 @@ import os
 
 import psutil
 
-from emote.callbacks import LoggingCallback
+from emote.callback import Callback
+from emote.callbacks import LoggingMixin
 
 
-class SystemLogger(LoggingCallback):
+class SystemLogger(LoggingMixin, Callback):
     def __init__(self):
         super().__init__(cycle=1_000)
         self._proc = psutil.Process(os.getpid())

--- a/emote/memory/callbacks.py
+++ b/emote/memory/callbacks.py
@@ -3,7 +3,7 @@ import os
 import time
 
 from emote import Callback
-from emote.callbacks import LoggingCallback
+from emote.callbacks import LoggingMixin
 from emote.utils import BlockTimers
 
 from .table import Table
@@ -41,7 +41,7 @@ class MemoryImporterCallback(Callback):
         logging.info(f"Loading memory dump {restore_path}")
 
 
-class MemoryExporterCallback(LoggingCallback):
+class MemoryExporterCallback(LoggingMixin, Callback):
     """Export the memory at regular intervals"""
 
     def __init__(

--- a/emote/sac.py
+++ b/emote/sac.py
@@ -11,7 +11,8 @@ from emote.proxies import AgentProxy
 from emote.typing import AgentId, DictObservation, DictResponse, EpisodeState
 from emote.utils.gamma_matrix import discount, make_gamma_matrix, split_rollouts
 
-from .callbacks import LoggingCallback, LossCallback
+from .callback import Callback
+from .callbacks import LoggingMixin, LossCallback
 
 
 def soft_update_from_to(source, target, tau):  # From rlkit
@@ -62,7 +63,7 @@ class QLoss(LossCallback):
         return self.mse(q_value, q_target)
 
 
-class QTarget(LoggingCallback):
+class QTarget(LoggingMixin, Callback):
     r"""Creates rolling averages of the Q nets, and predicts q values using these.
 
     The module is responsible both for keeping the averages correct in the target q

--- a/experiments/gym/train_carracing.py
+++ b/experiments/gym/train_carracing.py
@@ -16,7 +16,8 @@ from torch.optim import Adam
 from torch.utils.tensorboard import SummaryWriter
 
 from emote import Trainer
-from emote.callbacks import LoggingCallback, TensorboardLogger
+from emote.callback import Callback
+from emote.callbacks import LoggingMixin, TensorboardLogger
 from emote.env.box2d import make_vision_box2d_env
 from emote.memory import MemoryLoader, TableMemoryProxy
 from emote.memory.builder import DictObsNStepTable
@@ -58,7 +59,7 @@ class Policy(nn.Module):
         return list(self.mlp_encoder.parameters()) + list(self.policy.parameters())
 
 
-class ImageLoggerCallback(LoggingCallback):
+class ImageLoggerCallback(LoggingMixin, Callback):
     def __init__(self):
         super().__init__()
         self.data_group = "default"

--- a/tests/gym/collector.py
+++ b/tests/gym/collector.py
@@ -9,11 +9,11 @@ from collections import deque
 from tests.gym.dict_gym_wrapper import DictGymWrapper
 
 from emote.callback import Callback
-from emote.callbacks import LoggingCallback
+from emote.callbacks import LoggingMixin
 from emote.proxies import AgentProxy, MemoryProxy
 
 
-class GymCollector(LoggingCallback):
+class GymCollector(LoggingMixin, Callback):
     MAX_NUMBER_REWARDS = 1000
 
     def __init__(


### PR DESCRIPTION
This changes LoggingCallback to be a mixin class instead. This decouples it from the callback system, making it reusable as a baseclass for proxies and other objects that live on the inference side.