### PR TITLE
Add documentation about writing docs

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,8 +1,8 @@
 # 📚 Documentation
 
-To write documentation for *emote* we support both classic *ReStructured Text* (`.rst`) and modern `MarkDown` (`.md`) files. These can also reference each other, though for ease of use a tree should maintain the same type.
+To write documentation for *emote* we support both classic *ReStructured Text* (`.rst`) and modern `Markdown` (`.md`) files. These can also reference each other, though for ease of use a tree should maintain the same type.
 
-To include RST text into MarkDown code, use the following pattern:
+To include RST text into Markdown code, use the following pattern:
 
 
     ```{eval-rst}

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,22 @@
+# 📚 Documentation
+
+To write documentation for *emote* we support both classic *ReStructured Text* (`.rst`) and modern `MarkDown` (`.md`) files. These can also reference each other, though for ease of use a tree should maintain the same type.
+
+To include RST text into MarkDown code, use the following pattern:
+
+
+    ```{eval-rst}
+    .. include:: snippets/include-rst.rst
+	```
+
+That is to say, a code-block with the `eval-rst` directive and then a verbatim include of the markdown contents. The opposite, including Markdown in ReST can be achieved with this recipe:
+
+    .. include:: include.md
+       :parser: myst_parser.sphinx_
+
+See the [Myst documentation](https://myst-parser.readthedocs.io/en/latest/faq/index.html) for more recipes and directives.
+
+## Helpful commands
+
+* To build the docs: `pdm run docs`
+* To view the docs in your browser: `pdm run docs-serve`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ to build other algorithms.
    self
    installing-torch
    coding-standard
+   📚 Editing documentation <documentation.md>
 
 .. toctree::
    :maxdepth: 6
@@ -53,6 +54,8 @@ to build other algorithms.
 
 ..
    .. include:: adr/doc.md
+   .. include:: documentation.md
+
 	  :parser: myst_parser.sphinx_
 
 * :ref:`genindex`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ docs = [
 [tool.pdm.scripts]
 post_install = "pdm plugin add pdm-plugin-torch==23.0.0"
 post_lock = "pdm torch lock"
+docs = "bash -c 'cd docs && rm -rf _build/dirhtml/ && make dirhtml'"
+docs-serve = "python -m http.server --directory docs/_build/dirhtml"
 
 [[tool.pdm.source]]
 type = "index"


### PR DESCRIPTION
Adds a documentation page about working with documentation in different formats. Also adds two short commands (both in docs and pyproject) to work with docs files.