### PR TITLE
Ignore pypackages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ runs/**
 /dist/
 /.buildkite/digest.txt
 /docs/adr/
+
+__pypackages__/


### PR DESCRIPTION
Updating with PDM caused me to have 10k new files to add in git. Ignoring __pypackages__ seems sensible.