### PR TITLE
Missing return statement in AlphaLoss

### DIFF
--- a/emote/sac.py
+++ b/emote/sac.py
@@ -293,6 +293,7 @@ class AlphaLoss(LossCallback):
     def state_dict(self):
         state = super().state_dict()
         state["network_state_dict"] = self.ln_alpha
+        return state
 
     def load_state_dict(self, state_dict: Dict[str, Any]):
         self.ln_alpha = state_dict.pop("network_state_dict")


### PR DESCRIPTION
When trying to load a state dictionary for the alpha loss (e.g. from checkpoints), there was a problem with a None value being assigned. This came from a missing return statement in the function where the state dictionary is loaded, which is added here.