### PR TITLE
ensure memory exports are readable everywhere

### DIFF
--- a/emote/memory/table.py
+++ b/emote/memory/table.py
@@ -230,6 +230,8 @@ class ArrayTable:
 
     def store(self, path: str) -> bool:
         """Persist the whole table and all metadata into the designated name"""
+        import os
+        import stat
         import zipfile
 
         import cloudpickle
@@ -258,6 +260,10 @@ class ArrayTable:
 
                         with zip_.open(f"{key}.npy", "w", force_zip64=True) as npz:
                             np.save(npz, data)
+
+            os.chmod(
+                f"{path}.zip", stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+            )
 
     def restore(self, path: str) -> bool:
         """Restore the data table from the provided path. This currently implies a "clear" of the data stores."""

--- a/tests/test_memory_exporter.py
+++ b/tests/test_memory_exporter.py
@@ -1,7 +1,7 @@
 import os
+import stat
 
-from tempfile import mkdtemp
-
+import pytest
 import torch
 
 from gymnasium.vector import AsyncVectorEnv
@@ -20,9 +20,8 @@ from emote.sac import FeatureAgentProxy
 N_HIDDEN = 10
 
 
-def test_memory_export():
-    experiment_load_dir = mkdtemp()
-
+@pytest.mark.filterwarnings("ignore:Exporting a memory")
+def test_memory_export(tmpdir):
     device = torch.device("cpu")
     env = DictGymWrapper(AsyncVectorEnv(10 * [HitTheMiddle]))
     table = DictObsTable(spaces=env.dict_space, maxlen=10000, device=device)
@@ -31,7 +30,7 @@ def test_memory_export():
         memory=memory_proxy,
         target_memory_name="memory",
         inf_steps_per_memory_export=10,
-        experiment_root_path=experiment_load_dir,
+        experiment_root_path=tmpdir,
         min_time_per_export=1,
     )
     dataloader = MemoryLoader(table, 100, 2, "batch_size")
@@ -51,10 +50,10 @@ def test_memory_export():
     importer = MemoryImporterCallback(
         memory=DictObsTable(spaces=env.dict_space, maxlen=10000, device=device),
         target_memory_name="memory",
-        experiment_load_dir=experiment_load_dir,
+        experiment_load_dir=tmpdir,
     )
 
-    importer.memory.restore(os.path.join(experiment_load_dir, "memory_export"))
+    importer.memory.restore(os.path.join(tmpdir, "memory_export"))
 
     for column in importer.memory._columns.values():
         if isinstance(importer.memory._data[column.name], BaseStorage):
@@ -66,3 +65,39 @@ def test_memory_export():
                 )
 
     env.close()
+
+
+@pytest.mark.filterwarnings("ignore:Exporting a memory")
+def test_memory_export_permissions(tmpdir):
+    device = torch.device("cpu")
+    env = DictGymWrapper(AsyncVectorEnv(10 * [HitTheMiddle]))
+    table = DictObsTable(spaces=env.dict_space, maxlen=10000, device=device)
+    memory_proxy = TableMemoryProxy(table)
+    memory_proxy = MemoryExporterProxyWrapper(
+        memory=memory_proxy,
+        target_memory_name="memory",
+        inf_steps_per_memory_export=10,
+        experiment_root_path=tmpdir,
+        min_time_per_export=1,
+    )
+    dataloader = MemoryLoader(table, 100, 2, "batch_size")
+    policy = Policy(2, 1, [N_HIDDEN, N_HIDDEN])
+    agent_proxy = FeatureAgentProxy(policy, device)
+
+    callbacks = [
+        SimpleGymCollector(
+            env, agent_proxy, memory_proxy, warmup_steps=500, render=False
+        ),
+        BackPropStepsTerminator(2500),
+    ]
+
+    trainer = Trainer(callbacks, dataloader)
+    trainer.train()
+
+    assert os.path.exists(os.path.join(tmpdir, "memory_export.zip"))
+    st = os.stat(os.path.join(tmpdir, "memory_export.zip"))
+    # has to be readable by the whole world
+    required_perms = stat.S_IRUSR | stat.S_IROTH | stat.S_IRGRP
+    assert (
+        st.st_mode & required_perms
+    ) == required_perms, "file should be readable by everyone"


### PR DESCRIPTION
atomic_writes (which is also unmaintained nowadays! 😱) unfortunately has restrictive permissions. By default, it'll only allow the owner to read or write. This is overly restrictive and sometimes leads to errors during cloud training.

This PR ensures we expand those permissions to `u+rw g+w o+w`.