### PR TITLE
Upgrade Memory Warmup callback to handle exports and early shutdowns

### DIFF
--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -13,12 +13,14 @@ import warnings
 
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Dict, List, Mapping, Optional, Tuple, Union
+from typing import Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 from torch.utils.tensorboard import SummaryWriter
 
 from emote.callback import Callback
 from emote.callbacks import LoggingMixin
+from emote.extra.onnx_exporter import OnnxExporter
+from emote.trainer import TrainingShutdownException
 
 from ..typing import AgentId, DictObservation, DictResponse, EpisodeState
 from ..utils import BlockTimers, TimedBlock
@@ -374,13 +376,25 @@ class MemoryWarmup(Callback):
     loop and prevent progress.
     """
 
-    def __init__(self, loader: MemoryLoader):
+    def __init__(
+        self,
+        loader: MemoryLoader,
+        exporter: OnnxExporter,
+        shutdown_signal: Callable[[], bool] = None,
+    ):
         super().__init__()
         self._order = 100
         self._loader = loader
+        self._exporter = exporter
+
+        self._shutdown_signal = shutdown_signal or (lambda: False)
 
     def begin_training(self):
         import time
 
         while not self._loader.is_ready():
             time.sleep(0.1)
+            self._exporter.process_pending_exports()
+
+            if self._shutdown_signal():
+                raise TrainingShutdownException

--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -379,14 +379,13 @@ class MemoryWarmup(Callback):
     def __init__(
         self,
         loader: MemoryLoader,
-        exporter: OnnxExporter,
-        shutdown_signal: Callable[[], bool] = None,
+        exporter: Optional[OnnxExporter],
+        shutdown_signal: Optional[Callable[[], bool]] = None,
     ):
         super().__init__()
         self._order = 100
         self._loader = loader
         self._exporter = exporter
-
         self._shutdown_signal = shutdown_signal or (lambda: False)
 
     def begin_training(self):
@@ -394,7 +393,8 @@ class MemoryWarmup(Callback):
 
         while not self._loader.is_ready():
             time.sleep(0.1)
-            self._exporter.process_pending_exports()
+            if self._exporter:
+                self._exporter.process_pending_exports()
 
             if self._shutdown_signal():
                 raise TrainingShutdownException


### PR DESCRIPTION
We've had a shim for this exports in production, and I've noticed it can block early shutdowns since it won't check the shutdown signal.