### PR TITLE
work around memory leak in torch.jit.trace

### DIFF
--- a/emote/extra/onnx_exporter.py
+++ b/emote/extra/onnx_exporter.py
@@ -155,6 +155,10 @@ class OnnxExporter(LoggingMixin, Callback):
 
             self.policy.train(False)
 
+            # NOTE: This might seem like a good use case for torch.jit.trace,
+            # but it unfortunately leaks a full copy of the neural network.
+            # See: https://github.com/pytorch/pytorch/issues/82532
+
             with io.BytesIO() as f:
                 torch.onnx.export(
                     model=self.policy,

--- a/emote/extra/onnx_exporter.py
+++ b/emote/extra/onnx_exporter.py
@@ -155,21 +155,10 @@ class OnnxExporter(LoggingMixin, Callback):
 
             self.policy.train(False)
 
-            with torch.jit.optimized_execution(True):
-                with torch.no_grad():
-                    trace = torch.jit.trace(
-                        self.policy,
-                        args,
-                        check_trace=True,
-                        check_tolerance=1e-05,
-                    )
-
-            self.policy.train(True)
-
             with io.BytesIO() as f:
                 torch.onnx.export(
-                    model=trace,
-                    args=args,
+                    model=self.policy,
+                    args=tuple(args),
                     f=f,
                     input_names=list(map(lambda pair: pair[0], self.inputs)),
                     output_names=list(map(lambda pair: pair[0], self.outputs)),
@@ -179,6 +168,8 @@ class OnnxExporter(LoggingMixin, Callback):
                     },
                     opset_version=13,
                 )
+
+                self.policy.train(True)
 
                 f.seek(0)
                 model_proto = onnx.load_model(f, onnx.ModelProto)


### PR DESCRIPTION
Repro'd and confirmed using the methodology here: https://github.com/pytorch/pytorch/issues/82532

We leak every single tensor in the model each iteration. I validated it by inserting the code from the above issue into test_htm_onnx and running `exporter.export` in a loop at the end. This is the objgraph growth per iteration:
```
tuple                16813       +44
dict                 13502       +23
ReferenceType         5569       +22
type                  3021       +22
Tensor                 340        +8
StorageItem             31        +1
StorageItemHandle       31        +1
```
Changing the code in this PR makes the growth only the following:
```
dict                 12921        +1
StorageItem            132        +1
StorageItemHandle      132        +1
```