### PR TITLE
Add support for custom weight decay optimizer

### DIFF
--- a/emote/optimizers.py
+++ b/emote/optimizers.py
@@ -2,37 +2,44 @@
 # https://github.com/karpathy/minGPT/blob/3ed14b2cec0dfdad3f4b2831f2b4a86d11aef150/mingpt/model.py#L136
 # (MIT license)
 
-from typing import List, Optional, Set, Tuple
+from __future__ import annotations
+
+from typing import Type
 
 import torch
 
 
 def separate_modules_for_weight_decay(
     network: torch.nn.Module,
-    whitelist_weight_modules: Tuple[torch.nn.Module],
-    blacklist_weight_modules: Tuple[torch.nn.Module],
-    layers_to_exclude: Optional[List[str]] = None,
-) -> Tuple[Set, Set]:
+    whitelist_weight_modules: tuple[Type[torch.nn.Module], ...],
+    blacklist_weight_modules: tuple[Type[torch.nn.Module], ...],
+    layers_to_exclude: set[str] | None = None,
+) -> tuple[set[str], set[str]]:
     """Separate the parameters of network into two sets: one set of parameters that will have weight decay, and one set that will not.
 
     Args:
         network (torch.nn.Module): Network whose modules we want to separate.
-        whitelist_weight_modules (Tuple[torch.nn.Module]): Modules that should have weight decay applied to the weights.
-        blacklist_weight_modules (Tuple[torch.nn.Module]): Modules that should not have weight decay applied to the weights.
-        layers_to_exclude (Optional[List[str]], optional): Names of layers that should be excluded. Defaults to None.
+        whitelist_weight_modules (tuple[Type[torch.nn.Module], ...]): Modules that should have weight decay applied to the weights.
+        blacklist_weight_modules (tuple[Type[torch.nn.Module], ...]): Modules that should not have weight decay applied to the weights.
+        layers_to_exclude (set[str] | None, optional): Names of layers that should be excluded. Defaults to None.
 
     Returns:
-        Tuple(Set, Set): Sets of modules with and without weight decay.
+        tuple[set[str], set[str]]: Sets of modules with and without weight decay.
     """
+    # Make sure the same module doesn't appear in both whitelist_weight_modules and blacklist_weight_modules
+    assert (
+        len(set(whitelist_weight_modules) & set(blacklist_weight_modules)) == 0
+    ), "Some modules are both whitelisted and blacklisted!"
 
+    layers_to_exclude = layers_to_exclude or set()
     decay = set()
     no_decay = set()
 
     for mn, m in network.named_modules():
         for pn, p in m.named_parameters():
-            fpn = "%s.%s" % (mn, pn) if mn else pn
+            fpn = f"{mn}.{pn}" if mn else pn
 
-            if layers_to_exclude is not None and mn in layers_to_exclude:
+            if mn in layers_to_exclude:
                 # Weights of excluded layers will NOT be weight decayed
                 no_decay.add(fpn)
             elif pn.endswith("bias"):
@@ -51,26 +58,27 @@ def separate_modules_for_weight_decay(
 class ModifiedAdamW(torch.optim.AdamW):
     """Modifies AdamW (Adam with weight decay) to not apply weight decay on the bias and layer normalization weights, and optionally additional modules.
 
-    Arguments:
-        :param network: network
-        :param learning_rate: learning rate
-        :param weight_decay: weight decay coefficient
-        :param whitelist_weight_modules: params to get weight decay
-            (default: (torch.nn.Linear))
-        :param blacklist_weight_modules: params to not get weight decay
-            (default: (torch.nn.LayerNorm))
-        :param layers_to_exclude: list of names of additional layers to exclude, e.g. last layer of Q-network
-            (default: None)
+    Args:
+        network (torch.nn.Module): network
+        lr (float): learning rate
+        weight_decay (float): weight decay coefficient
+        whitelist_weight_modules (tuple[Type[torch.nn.Module], ...], optional): params to get weight decay. Defaults to (torch.nn.Linear, ).
+        blacklist_weight_modules (tuple[Type[torch.nn.Module], ...], optional): params to not get weight decay. Defaults to (torch.nn.LayerNorm, ).
+        layers_to_exclude (set[str] | None, optional): set of names of additional layers to exclude, e.g. last layer of Q-network. Defaults to None.
     """
 
     def __init__(
         self,
-        network,
-        lr,
-        weight_decay,
-        whitelist_weight_modules: Tuple[torch.nn.Module] = (torch.nn.Linear),
-        blacklist_weight_modules: Tuple[torch.nn.Module] = (torch.nn.LayerNorm),
-        layers_to_exclude: List[str] = None,
+        network: torch.nn.Module,
+        lr: float,
+        weight_decay: float,
+        whitelist_weight_modules: tuple[Type[torch.nn.Module], ...] = (
+            torch.nn.Linear,
+        ),
+        blacklist_weight_modules: tuple[Type[torch.nn.Module], ...] = (
+            torch.nn.LayerNorm,
+        ),
+        layers_to_exclude: set[str] | None = None,
     ):
         decay, no_decay = separate_modules_for_weight_decay(
             network,
@@ -79,15 +87,15 @@ class ModifiedAdamW(torch.optim.AdamW):
             layers_to_exclude,
         )
 
-        param_dict = {pn: p for pn, p in network.named_parameters()}
+        param_dict = dict(network.named_parameters())
 
         optim_groups = [
             {
-                "params": [param_dict[pn] for pn in sorted(list(decay))],
+                "params": [param_dict[pn] for pn in decay],
                 "weight_decay": weight_decay,
             },
             {
-                "params": [param_dict[pn] for pn in sorted(list(no_decay))],
+                "params": [param_dict[pn] for pn in no_decay],
                 "weight_decay": 0.0,
             },
         ]

--- a/emote/optimizers.py
+++ b/emote/optimizers.py
@@ -1,0 +1,95 @@
+# Adapted from
+# https://github.com/karpathy/minGPT/blob/3ed14b2cec0dfdad3f4b2831f2b4a86d11aef150/mingpt/model.py#L136
+# (MIT license)
+
+from typing import List, Optional, Set, Tuple
+
+import torch
+
+
+def separate_modules_for_weight_decay(
+    network: torch.nn.Module,
+    whitelist_weight_modules: Tuple[torch.nn.Module],
+    blacklist_weight_modules: Tuple[torch.nn.Module],
+    layers_to_exclude: Optional[List[str]] = None,
+) -> Tuple[Set, Set]:
+    """Separate the parameters of network into two sets: one set of parameters that will have weight decay, and one set that will not.
+
+    Args:
+        network (torch.nn.Module): Network whose modules we want to separate.
+        whitelist_weight_modules (Tuple[torch.nn.Module]): Modules that should have weight decay applied to the weights.
+        blacklist_weight_modules (Tuple[torch.nn.Module]): Modules that should not have weight decay applied to the weights.
+        layers_to_exclude (Optional[List[str]], optional): Names of layers that should be excluded. Defaults to None.
+
+    Returns:
+        Tuple(Set, Set): Sets of modules with and without weight decay.
+    """
+
+    decay = set()
+    no_decay = set()
+
+    for mn, m in network.named_modules():
+        for pn, p in m.named_parameters():
+            fpn = "%s.%s" % (mn, pn) if mn else pn
+
+            if layers_to_exclude is not None and mn in layers_to_exclude:
+                # Weights of excluded layers will NOT be weight decayed
+                no_decay.add(fpn)
+            elif pn.endswith("bias"):
+                # Biases will not be decayed
+                no_decay.add(fpn)
+            elif pn.endswith("weight") and isinstance(m, blacklist_weight_modules):
+                # Weights of blacklist modules will NOT be weight decayed
+                no_decay.add(fpn)
+            elif pn.endswith("weight") and isinstance(m, whitelist_weight_modules):
+                # Weights of whitelist modules will be weight decayed
+                decay.add(fpn)
+
+    return decay, no_decay
+
+
+class ModifiedAdamW(torch.optim.AdamW):
+    """Modifies AdamW (Adam with weight decay) to not apply weight decay on the bias and layer normalization weights, and optionally additional modules.
+
+    Arguments:
+        :param network: network
+        :param learning_rate: learning rate
+        :param weight_decay: weight decay coefficient
+        :param whitelist_weight_modules: params to get weight decay
+            (default: (torch.nn.Linear))
+        :param blacklist_weight_modules: params to not get weight decay
+            (default: (torch.nn.LayerNorm))
+        :param layers_to_exclude: list of names of additional layers to exclude, e.g. last layer of Q-network
+            (default: None)
+    """
+
+    def __init__(
+        self,
+        network,
+        lr,
+        weight_decay,
+        whitelist_weight_modules: Tuple[torch.nn.Module] = (torch.nn.Linear),
+        blacklist_weight_modules: Tuple[torch.nn.Module] = (torch.nn.LayerNorm),
+        layers_to_exclude: List[str] = None,
+    ):
+        decay, no_decay = separate_modules_for_weight_decay(
+            network,
+            whitelist_weight_modules,
+            blacklist_weight_modules,
+            layers_to_exclude,
+        )
+
+        param_dict = {pn: p for pn, p in network.named_parameters()}
+
+        optim_groups = [
+            {
+                "params": [param_dict[pn] for pn in sorted(list(decay))],
+                "weight_decay": weight_decay,
+            },
+            {
+                "params": [param_dict[pn] for pn in sorted(list(no_decay))],
+                "weight_decay": 0.0,
+            },
+        ]
+
+        super().__init__(optim_groups, lr)

--- a/tests/test_modified_adamw.py
+++ b/tests/test_modified_adamw.py
@@ -51,7 +51,7 @@ def num_groups(param_groups):
             wd += 1
         else:
             no_wd += 1
-        
+
     assert (
         wd == 1
     ), f"There should be one group that has weight decay, but there are {wd}"
@@ -75,7 +75,7 @@ def test_module_separation():
     param_dict = dict(q.named_parameters())
 
     module_separation(param_dict, decay, no_decay)
-    
+
     # Make sure the test fails when a module is not added to either of the sets
     with pytest.raises(
         AssertionError,
@@ -91,7 +91,7 @@ def test_module_separation():
     ):
         decay.add("test")
         no_decay.add("test")
-        
+
         module_separation(param_dict, decay, no_decay)
 
 
@@ -107,7 +107,7 @@ def test_num_groups():
     )
 
     num_groups(q_optim.param_groups)
-    
+
     # Make sure the test fails when a group with weight decay doesn't exist
     with pytest.raises(
         AssertionError,

--- a/tests/test_modified_adamw.py
+++ b/tests/test_modified_adamw.py
@@ -1,0 +1,83 @@
+from functools import partial
+
+import torch
+
+from torch import nn
+
+from emote.nn.initialization import ortho_init_
+from emote.optimizers import ModifiedAdamW, separate_modules_for_weight_decay
+
+
+class QNet(nn.Module):
+    def __init__(self, num_obs, num_actions, hidden_dims):
+        super().__init__()
+
+        all_dims = [num_obs + num_actions] + hidden_dims
+
+        self.encoder = nn.Sequential(
+            *[
+                nn.Sequential(nn.Linear(n_in, n_out), nn.LayerNorm(n_out), nn.ReLU())
+                for n_in, n_out in zip(all_dims, hidden_dims)
+            ],
+        )
+        self.encoder.apply(ortho_init_)
+
+        self.final_layer = nn.Linear(hidden_dims[-1], 1)
+        self.final_layer.apply(partial(ortho_init_, gain=1))
+
+    def forward(self, action, obs):
+        x = torch.cat([obs, action], dim=1)
+        return self.final_layer(self.encoder(x))
+
+
+def test_module_separation():
+    """Validate that all parameters are added to either "decay" or "no_decay"."""
+    q = QNet(2, 2, [2, 2])
+
+    decay, no_decay = separate_modules_for_weight_decay(
+        q,
+        whitelist_weight_modules=(torch.nn.Linear),
+        blacklist_weight_modules=(torch.nn.LayerNorm),
+        layers_to_exclude=["final_layer"],
+    )
+
+    param_dict = {pn: p for pn, p in q.named_parameters()}
+
+    inter_params = decay & no_decay
+    union_params = decay | no_decay
+
+    assert (
+        len(inter_params) == 0
+    ), "Parameters %s made it into both decay/no_decay sets!" % (str(inter_params),)
+
+    assert (
+        len(param_dict.keys() - union_params) == 0
+    ), "Parameters %s were not separated into either decay/no_decay set!" % (
+        str(param_dict.keys() - union_params),
+    )
+
+
+def test_num_groups():
+    """Validate that only two groups of parameters exist: one that gets weight decay and one that doesn't."""
+    q = QNet(2, 2, [2, 2])
+    q_optim = ModifiedAdamW(
+        network=q,
+        lr=0.001,
+        weight_decay=0.01,
+        layers_to_exclude=["final_layer"],
+    )
+
+    wd, no_wd = 0, 0
+    for group in q_optim.param_groups:
+        if group["weight_decay"] != 0:
+            wd += 1
+        else:
+            no_wd += 1
+
+    assert (
+        wd == 1
+    ), f"There should be one group that has weight decay, but there are {wd}"
+
+    assert (
+        no_wd == 1
+    ), f"There should be one group that has weight decay, but there are {no_wd}"

--- a/tests/test_modified_adamw.py
+++ b/tests/test_modified_adamw.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+import pytest
 import torch
 
 from torch import nn
@@ -30,36 +31,74 @@ class QNet(nn.Module):
         return self.final_layer(self.encoder(x))
 
 
+def module_separation(param_dict, decay, no_decay):
+    inter_params = decay & no_decay
+    union_params = decay | no_decay
+
+    assert (
+        len(inter_params) == 0
+    ), f"Parameters {str(inter_params)} made it into both decay/no_decay sets!"
+
+    assert (
+        len(param_dict.keys() - union_params) == 0
+    ), f"Parameters {str(param_dict.keys() - union_params)} were not separated into either decay/no_decay set!"
+
+
+def num_groups(param_groups):
+    wd, no_wd = 0, 0
+    for group in param_groups:
+        if group["weight_decay"] != 0:
+            wd += 1
+        else:
+            no_wd += 1
+        
+    assert (
+        wd == 1
+    ), f"There should be one group that has weight decay, but there are {wd}"
+
+    assert (
+        no_wd == 1
+    ), f"There should be one group that has no weight decay, but there are {no_wd}"
+
+
 def test_module_separation():
     """Validate that all parameters are added to either "decay" or "no_decay"."""
     q = QNet(2, 2, [2, 2])
 
     decay, no_decay = separate_modules_for_weight_decay(
         q,
-        whitelist_weight_modules=(torch.nn.Linear),
-        blacklist_weight_modules=(torch.nn.LayerNorm),
-        layers_to_exclude=["final_layer"],
+        whitelist_weight_modules=(torch.nn.Linear,),
+        blacklist_weight_modules=(torch.nn.LayerNorm,),
+        layers_to_exclude={"final_layer"},
     )
 
-    param_dict = {pn: p for pn, p in q.named_parameters()}
+    param_dict = dict(q.named_parameters())
 
-    inter_params = decay & no_decay
-    union_params = decay | no_decay
+    module_separation(param_dict, decay, no_decay)
+    
+    # Make sure the test fails when a module is not added to either of the sets
+    with pytest.raises(
+        AssertionError,
+        match="Parameters {'test'} were not separated into either decay/no_decay set!",
+    ):
+        param_dict["test"] = None
+        module_separation(param_dict, decay, no_decay)
 
-    assert (
-        len(inter_params) == 0
-    ), "Parameters %s made it into both decay/no_decay sets!" % (str(inter_params),)
-
-    assert (
-        len(param_dict.keys() - union_params) == 0
-    ), "Parameters %s were not separated into either decay/no_decay set!" % (
-        str(param_dict.keys() - union_params),
-    )
+    # Make sure the test fails when a module is added to both of the sets
+    with pytest.raises(
+        AssertionError,
+        match="Parameters {'test'} made it into both decay/no_decay sets!",
+    ):
+        decay.add("test")
+        no_decay.add("test")
+        
+        module_separation(param_dict, decay, no_decay)
 
 
 def test_num_groups():
     """Validate that only two groups of parameters exist: one that gets weight decay and one that doesn't."""
     q = QNet(2, 2, [2, 2])
+
     q_optim = ModifiedAdamW(
         network=q,
         lr=0.001,
@@ -67,17 +106,25 @@ def test_num_groups():
         layers_to_exclude=["final_layer"],
     )
 
-    wd, no_wd = 0, 0
-    for group in q_optim.param_groups:
-        if group["weight_decay"] != 0:
-            wd += 1
-        else:
-            no_wd += 1
+    num_groups(q_optim.param_groups)
+    
+    # Make sure the test fails when a group with weight decay doesn't exist
+    with pytest.raises(
+        AssertionError,
+        match="There should be one group that has weight decay, but there are 0",
+    ):
+        for i in range(len(q_optim.param_groups)):
+            if q_optim.param_groups[i]["weight_decay"] > 0:
+                del q_optim.param_groups[i]
+                break
 
-    assert (
-        wd == 1
-    ), f"There should be one group that has weight decay, but there are {wd}"
+        num_groups(q_optim.param_groups)
 
-    assert (
-        no_wd == 1
-    ), f"There should be one group that has weight decay, but there are {no_wd}"
+    # Make sure the test fails when multiple groups with weight decay exist
+    with pytest.raises(
+        AssertionError,
+        match="There should be one group that has weight decay, but there are 2",
+    ):
+        q_optim.param_groups += [{"weight_decay": 0.1}, {"weight_decay": 0.2}]
+
+        num_groups(q_optim.param_groups)


### PR DESCRIPTION
Creates a modified AdamW (that inherits from the standard AdamW) as suggested in _[Efficient deep reinforcement learning requires regulating overfitting](https://arxiv.org/pdf/2304.10466.pdf)_.

ModifiedAdamW disables weight decay for the bias, additional modules (such as LayerNorm), and specific named layers (e.g. the paper suggests excluding the final layer in the Q networks, which can be done by passing `layers_to_exclude = ["final_layer"]`). 

The function for separating the modules was adapted from a [PyTorch minGPT implementation](https://github.com/karpathy/minGPT/blob/3ed14b2cec0dfdad3f4b2831f2b4a86d11aef150/mingpt/model.py#L136) that is MIT licensed.