### PR TITLE
Add Storage Subdirectory

### DIFF
--- a/emote/callbacks.py
+++ b/emote/callbacks.py
@@ -397,7 +397,9 @@ class Checkpointer(Callback):
             "checkpoint_index": self._checkpoint_index,
         }
         name = f"checkpoint_{self._checkpoint_index}.tar"
-        final_path = os.path.join(self._path, self._storage_subdirectory, name)
+        folder_path = os.path.join(self._path, self._storage_subdirectory)
+        os.makedirs(folder_path, exist_ok=True)
+        final_path = os.path.join(folder_path, name)
         torch.save(state_dict, final_path)
         self._checkpoint_index += 1
 
@@ -445,7 +447,9 @@ class CheckpointLoader(Callback):
 
     def begin_training(self):
         name = f"checkpoint_{self._checkpoint_index}.tar"
-        final_path = os.path.join(self._path, self._storage_subdirectory, name)
+        folder_path = os.path.join(self._path, self._stored_subdirectory)
+        os.makedirs(folder_path, exist_ok=True)
+        final_path = os.path.join(folder_path, name)
         state_dict: dict = torch.load(final_path)
         for cb, state in zip(self._cbs, state_dict["callback_state_dicts"]):
             cb.load_state_dict(state)

--- a/emote/callbacks.py
+++ b/emote/callbacks.py
@@ -380,7 +380,7 @@ class Checkpointer(Callback):
         checkpoint_index: int = 0,
         optimizers: Optional[List[optim.Optimizer]] = None,
         networks: Optional[List[nn.Module]] = None,
-        storage_subdirectory: str = "checkpoints"
+        storage_subdirectory: str = "checkpoints",
     ):
         super().__init__(cycle=checkpoint_interval)
         self._cbs = callbacks
@@ -390,7 +390,7 @@ class Checkpointer(Callback):
         self._nets: List[nn.Module] = networks if networks else []
         self._folder_path = os.path.join(run_root, storage_subdirectory)
 
-    def begin_training(self): 
+    def begin_training(self):
         os.makedirs(self._folder_path, exist_ok=True)
 
     def end_cycle(self):
@@ -439,7 +439,7 @@ class CheckpointLoader(Callback):
         reset_training_steps: bool = False,
         optimizers: Optional[List[optim.Optimizer]] = None,
         networks: Optional[List[nn.Module]] = None,
-        storage_subdirectory: str = "checkpoints"
+        storage_subdirectory: str = "checkpoints",
     ):
         super().__init__()
         self._cbs = callbacks
@@ -452,7 +452,9 @@ class CheckpointLoader(Callback):
 
     def begin_training(self):
         if not os.path.exists(self._folder_path):
-            raise InvalidCheckpointLocation(f"Checkpoint folder {self._folder_path} was specified but does not exist.")
+            raise InvalidCheckpointLocation(
+                f"Checkpoint folder {self._folder_path} was specified but does not exist."
+            )
         name = f"checkpoint_{self._checkpoint_index}.tar"
         final_path = os.path.join(self._folder_path, name)
         state_dict: dict = torch.load(final_path)
@@ -529,5 +531,6 @@ class BatchCallback(LoggingMixin, Callback):
     def get_batch(self, *args, **kwargs):
         pass
 
-class InvalidCheckpointLocation(ValueError): 
+
+class InvalidCheckpointLocation(ValueError):
     pass

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -46,7 +46,11 @@ def test_networks_checkpoint():
     chkpt_dir = mkdtemp()
     run_root = join(chkpt_dir, "chkpt")
     n1 = nn.Linear(1, 1)
-    c1 = [Checkpointer(networks=[n1], callbacks=[], run_root=run_root, checkpoint_interval=1)]
+    c1 = [
+        Checkpointer(
+            networks=[n1], callbacks=[], run_root=run_root, checkpoint_interval=1
+        )
+    ]
 
     t1 = Trainer(c1, onestep_dataloader())
     t1.state["inf_step"] = 0
@@ -58,7 +62,9 @@ def test_networks_checkpoint():
     assert not torch.allclose(n1(test_data), n2(test_data))
 
     c2 = [
-        CheckpointLoader(networks=[n2], callbacks=[], run_root=run_root, checkpoint_index=0),
+        CheckpointLoader(
+            networks=[n2], callbacks=[], run_root=run_root, checkpoint_index=0
+        ),
         BackPropStepsTerminator(1),
     ]
     t2 = Trainer(c2, nostep_dataloader())
@@ -84,7 +90,9 @@ def test_qloss_checkpoints():
     ql1 = QLoss(name="q", q=q1, opt=Adam(q1.parameters()))
     c1 = [
         ql1,
-        Checkpointer(networks=[], callbacks=[ql1], run_root=run_root, checkpoint_interval=1),
+        Checkpointer(
+            networks=[], callbacks=[ql1], run_root=run_root, checkpoint_interval=1
+        ),
     ]
 
     t1 = Trainer(c1, random_onestep_dataloader())
@@ -100,7 +108,9 @@ def test_qloss_checkpoints():
     ql2 = QLoss(name="q", q=q2, opt=Adam(q1.parameters()))
     c2 = [
         ql2,
-        CheckpointLoader(networks=[], callbacks=[ql2], run_root=run_root, checkpoint_index=0),
+        CheckpointLoader(
+            networks=[], callbacks=[ql2], run_root=run_root, checkpoint_index=0
+        ),
     ]
     t2 = Trainer(c2, nostep_dataloader())
     t2.train()

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -44,9 +44,9 @@ def onestep_dataloader() -> Generator:
 
 def test_networks_checkpoint():
     chkpt_dir = mkdtemp()
-    path = join(chkpt_dir, "chkpt")
+    run_root = join(chkpt_dir, "chkpt")
     n1 = nn.Linear(1, 1)
-    c1 = [Checkpointer(networks=[n1], callbacks=[], path=path, checkpoint_interval=1)]
+    c1 = [Checkpointer(networks=[n1], callbacks=[], run_root=run_root, checkpoint_interval=1)]
 
     t1 = Trainer(c1, onestep_dataloader())
     t1.state["inf_step"] = 0
@@ -58,7 +58,7 @@ def test_networks_checkpoint():
     assert not torch.allclose(n1(test_data), n2(test_data))
 
     c2 = [
-        CheckpointLoader(networks=[n2], callbacks=[], path=path, checkpoint_index=0),
+        CheckpointLoader(networks=[n2], callbacks=[], run_root=run_root, checkpoint_index=0),
         BackPropStepsTerminator(1),
     ]
     t2 = Trainer(c2, nostep_dataloader())
@@ -79,12 +79,12 @@ def random_onestep_dataloader() -> Generator:
 
 def test_qloss_checkpoints():
     chkpt_dir = mkdtemp()
-    path = join(chkpt_dir, "chkpt")
+    run_root = join(chkpt_dir, "chkpt")
     q1 = QNet(2, 1)
     ql1 = QLoss(name="q", q=q1, opt=Adam(q1.parameters()))
     c1 = [
         ql1,
-        Checkpointer(networks=[], callbacks=[ql1], path=path, checkpoint_interval=1),
+        Checkpointer(networks=[], callbacks=[ql1], run_root=run_root, checkpoint_interval=1),
     ]
 
     t1 = Trainer(c1, random_onestep_dataloader())
@@ -100,7 +100,7 @@ def test_qloss_checkpoints():
     ql2 = QLoss(name="q", q=q2, opt=Adam(q1.parameters()))
     c2 = [
         ql2,
-        CheckpointLoader(networks=[], callbacks=[ql2], path=path, checkpoint_index=0),
+        CheckpointLoader(networks=[], callbacks=[ql2], run_root=run_root, checkpoint_index=0),
     ]
     t2 = Trainer(c2, nostep_dataloader())
     t2.train()


### PR DESCRIPTION
This allows optionally specifying the name of the subdirectory for the checkpointer and checkpointloader, with the default being "checkpoints". 

We also create the "checkpoints" subdirectory from here. 

This is done in emote to avoid code duplication in downstream projects and match our existing practices, and because 99% of the time, we want the subfolder to be called "checkpoints". 