### PR TITLE
Enable setting `device` for ONNX exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - Now targetting torch version 1.12, up from 1.11.
+- `OnnxExporter` accepts a `device` argument to enable tracing on other devices.
 
 ### Deprecations
 

--- a/emote/extra/onnx_exporter.py
+++ b/emote/extra/onnx_exporter.py
@@ -73,7 +73,7 @@ class OnnxExporter(LoggingMixin, Callback):
                       it will be created.
     :param interval: if provided, will automatically export ONNX files at this cadence.
     :param prefix: all file names will have this prefix.
-
+    :param device: if provided, will transfer the model inputs to this device before exporting.
     """
 
     __HAS_INSERTED_FILTER = False
@@ -86,7 +86,7 @@ class OnnxExporter(LoggingMixin, Callback):
         directory: str,
         interval: int | None = None,
         prefix: str = "savedmodel_",
-        device: str = torch.device = None,
+        device: torch.device | None = None,
     ):
         super().__init__(cycle=interval)
 

--- a/emote/extra/onnx_exporter.py
+++ b/emote/extra/onnx_exporter.py
@@ -86,6 +86,7 @@ class OnnxExporter(LoggingMixin, Callback):
         directory: str,
         interval: int | None = None,
         prefix: str = "savedmodel_",
+        device: str = torch.device = None,
     ):
         super().__init__(cycle=interval)
 
@@ -124,6 +125,8 @@ class OnnxExporter(LoggingMixin, Callback):
         self.inputs = input_shapes
         self.outputs = output_shapes
 
+        self._device = device
+
     def end_batch(self):
         self.process_pending_exports()
 
@@ -151,7 +154,11 @@ class OnnxExporter(LoggingMixin, Callback):
             args = []
 
             for _, shape in self.inputs:
-                args.append(torch.randn(1, *shape).detach())
+                arg = torch.randn(1, *shape).detach()
+                if self._device is not None:
+                    arg = arg.to(self._device)
+
+                args.append(arg)
 
             self.policy.train(False)
 


### PR DESCRIPTION
This is necessary for GPU training as otherwise the args will be on the wrong device during training.