### PR TITLE
always flush after writing tb events

### DIFF
--- a/emote/callbacks/logging.py
+++ b/emote/callbacks/logging.py
@@ -77,6 +77,8 @@ class TensorboardLogger(Callback):
             "performance/bp_steps_per_sec", bp_step / time_since_start, bp_step
         )
 
+        self._writer.flush()
+
 
 class TerminalLogger(Callback):
     """Logs the provided loggable callbacks to the python logger."""

--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -260,6 +260,8 @@ class LoggingProxyWrapper(TableMemoryProxyWrapper, LoggingMixin):
             "performance/inf_steps_per_sec", inf_step / time_since_start, inf_step
         )
 
+        self._writer.flush()
+
         self._cycle_start_infs = self.completed_inferences
         self._cycle_start_time = now_time
 


### PR DESCRIPTION
I've seen some issues in cloud training where the NFS drive is receiving blocks out of sync, leading to Tensorboard reading zeroes, spotting an error, and then ignoring the file permanently. The error is the following:

```
[2023-06-02T19:18:24Z WARN  rustboard_core::run] Read error in /tmp/tensorboard-logs/ts/ml-inf/test-8h/0/events.out.tfevents.1685731159.brain-8156-wjjg5.1.1: ReadRecordError(BadLengthCrc(ChecksumError { got: MaskedCrc(0x07980329), want: MaskedCrc(0x00000000) }))
[2023-06-02T19:42:22Z WARN  rustboard_core::run] Read error in /tmp/tensorboard-logs/ts/ml-inf/test-8h/0/events.out.tfevents.1685731159.brain-8156-wjjg5.1.0: ReadRecordError(BadLengthCrc(ChecksumError { got: MaskedCrc(0x07980329), want: MaskedCrc(0x00000000) }))
```

It does sound like the following:
https://linux-kernel.vger.kernel.narkive.com/asPTesqS/nfs-blocks-of-zeros-nulls-in-nfs-files-in-kernels-2-6-20. This might be a sufficient change, or we might need higher fidelity of flushing. 

This is the upstream issue, which also occurs with torch: https://github.com/tensorflow/tensorboard/issues/5588. However; torch has no reported bugs for this, likely because it only occurs when using TB. It might also be some error in the shared drive setup, but I'm treating this as a the lower likelihood option right now.