### PR TITLE
Add Conv1d encoder and update Conv2d encoder with option to flatten

### DIFF
--- a/emote/nn/curl.py
+++ b/emote/nn/curl.py
@@ -175,11 +175,14 @@ class CurlLoss(LossCallback):
         self._augment_anchor_and_pos = augment_anchor_and_pos
         self._tau = tau
 
-        _, _, _, encoder_output_size = encoder_model.get_encoder_output_size(
-            return_flattened=True
-        )
+        encoder_output_size = encoder_model.get_encoder_output_size()
+
         if not encoder_model.flatten:
+            encoder_output_size = (
+                encoder_output_size[0] * encoder_output_size[1] * encoder_output_size[2]
+            )
             encoder_model = nn.Sequential(encoder_model, nn.Flatten())
+
         if not target_encoder_model.flatten:
             target_encoder_model = nn.Sequential(target_encoder_model, nn.Flatten())
 

--- a/emote/nn/layers.py
+++ b/emote/nn/layers.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from __future__ import annotations
 
 import numpy as np
 import torch
@@ -11,24 +11,26 @@ class Conv2dEncoder(nn.Module):
     """
     Multi-layer 2D convolutional encoder.
 
-    :param input_shape: (Tuple[int, int, int]) The input image shape, this should be consistent with channels_last.
-    :param channels: List[int] The number of channels for each conv layer.
-    :param kernels: List[int] The kernel size for each conv layer.
-    :param strides: List[int] The strides for each conv layer.
-    :param padding: List[int] The padding.
-    :param channels_last: bool Whether the input image has channels as the last dim, else first.
-    :param activation: torch.nn.Module The activation function.
+    :param input_shape: (tuple[int, int, int]) The input image shape, this should be consistent with channels_last.
+    :param channels: (list[int]) The number of channels for each conv layer.
+    :param kernels: (list[int]) The kernel size for each conv layer.
+    :param strides: (list[int]) The strides for each conv layer.
+    :param padding: (list[int]]) The padding.
+    :param channels_last: (bool) Whether the input image has channels as the last dim, else first.
+    :param activation: (torch.nn.Module) The activation function.
+    :param flatten: (bool) Flattens the output into a vector.
     """
 
     def __init__(
         self,
-        input_shape: Tuple[int, int, int],
-        channels: List[int],
-        kernels: List[int],
-        strides: List[int],
-        padding: List[int],
+        input_shape: tuple[int, int, int],
+        channels: list[int],
+        kernels: list[int],
+        strides: list[int],
+        padding: list[int],
         channels_last: bool = True,
         activation: torch.nn.Module = torch.nn.ReLU,
+        flatten: bool = True,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -42,6 +44,7 @@ class Conv2dEncoder(nn.Module):
         self._kernels = kernels
         self._strides = strides
         self._padding = padding
+        self.flatten = flatten
 
         num_layers = len(channels)
         channels = [self._img_shape_cwh[0]] + channels
@@ -59,6 +62,9 @@ class Conv2dEncoder(nn.Module):
             )
             self._layers.append(activation())
 
+        if self.flatten:
+            self._layers.append(nn.Flatten())
+
         self.apply(ortho_init_)
 
     def forward(self, obs: torch.Tensor):
@@ -69,7 +75,7 @@ class Conv2dEncoder(nn.Module):
             x = layer(x)
         return x
 
-    def get_encoder_output_size(self, flatten: bool = False):
+    def get_encoder_output_size(self, return_flattened: bool = False):
         curr_size_x, curr_size_y = self._img_shape_cwh[1], self._img_shape_cwh[2]
 
         """Calculate the outputs size of a conv encoder."""
@@ -78,6 +84,95 @@ class Conv2dEncoder(nn.Module):
             curr_size_y = ((curr_size_y - k + 2 * p) // s) + 1
 
         out_size = (self._channels[-1], curr_size_x, curr_size_y)
-        if flatten:
-            out_size = np.prod(out_size)
+
+        if self.flatten or return_flattened:
+            flattened_out_size = np.prod(out_size)
+            return *out_size, flattened_out_size
+
+        return out_size
+
+
+class Conv1dEncoder(nn.Module):
+    """
+    Multi-layer 1D convolutional encoder
+
+    :param input_shape: (tuple[int, int]) The input shape
+    :param channels: (list[int]) The number of channels for each conv layer.
+    :param kernels: (list[int]) The kernel size for each conv layer.
+    :param strides: (list[int]) The strides for each conv layer.
+    :param padding: (list[int]) The padding.
+    :param activation: (torch.nn.Module) The activation function.
+    :param flatten: (bool) Flattens the output into a vector.
+    :param name: (str) Name of the encoder (default: "conv1d")
+    :param channels_last: (bool) Whether the input has channels as the last dim, else first.
+    """
+
+    def __init__(
+        self,
+        input_shape: tuple[int, int],
+        channels: list[int],
+        kernels: list[int],
+        strides: list[int],
+        padding: list[int],
+        activation: torch.nn.Module = torch.nn.ReLU,
+        flatten: bool = True,
+        name: str = "conv1d",
+        channels_last: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._channels_last = channels_last
+        if channels_last:
+            self._input_shape = [input_shape[1], input_shape[0]]
+        else:
+            self._input_shape = input_shape
+
+        self._channels = channels
+        self._kernels = kernels
+        self._strides = strides
+        self._padding = padding
+        self.name = name
+        self.flatten = flatten
+
+        num_layers = len(channels)
+        channels = [self._input_shape[0]] + channels
+
+        self._layers = torch.nn.ModuleList()
+        for i in range(num_layers):
+            self._layers.append(
+                torch.nn.Conv1d(
+                    channels[i],
+                    channels[i + 1],
+                    kernels[i],
+                    strides[i],
+                    padding=padding[i],
+                )
+            )
+            self._layers.append(activation())
+
+        if self.flatten:
+            self._layers.append(nn.Flatten())
+
+        self.apply(ortho_init_)
+
+    def forward(self, obs: torch.Tensor):
+        x = obs
+        if self._channels_last:
+            x = x.permute(0, 2, 1)
+        for layer in self._layers:
+            x = layer(x)
+        return x
+
+    def get_encoder_output_size(self, return_flattened: bool = False):
+        curr_size = self._input_shape[1]
+
+        for k, s, p in zip(self._kernels, self._strides, self._padding):
+            curr_size = ((curr_size - k + 2 * p) // s) + 1
+
+        out_size = (self._channels[-1], curr_size)
+
+        if self.flatten or return_flattened:
+            flattened_out_size = np.prod(out_size)
+            return *out_size, flattened_out_size
+
         return out_size

--- a/emote/nn/layers.py
+++ b/emote/nn/layers.py
@@ -75,7 +75,7 @@ class Conv2dEncoder(nn.Module):
             x = layer(x)
         return x
 
-    def get_encoder_output_size(self, return_flattened: bool = False):
+    def get_encoder_output_size(self):
         curr_size_x, curr_size_y = self._img_shape_cwh[1], self._img_shape_cwh[2]
 
         """Calculate the outputs size of a conv encoder."""
@@ -85,9 +85,8 @@ class Conv2dEncoder(nn.Module):
 
         out_size = (self._channels[-1], curr_size_x, curr_size_y)
 
-        if self.flatten or return_flattened:
-            flattened_out_size = np.prod(out_size)
-            return *out_size, flattened_out_size
+        if self.flatten:
+            out_size = np.prod(out_size)
 
         return out_size
 
@@ -163,7 +162,7 @@ class Conv1dEncoder(nn.Module):
             x = layer(x)
         return x
 
-    def get_encoder_output_size(self, return_flattened: bool = False):
+    def get_encoder_output_size(self):
         curr_size = self._input_shape[1]
 
         for k, s, p in zip(self._kernels, self._strides, self._padding):
@@ -171,8 +170,7 @@ class Conv1dEncoder(nn.Module):
 
         out_size = (self._channels[-1], curr_size)
 
-        if self.flatten or return_flattened:
-            flattened_out_size = np.prod(out_size)
-            return *out_size, flattened_out_size
+        if self.flatten:
+            out_size = np.prod(out_size)
 
         return out_size

--- a/tests/test_conv1denc.py
+++ b/tests/test_conv1denc.py
@@ -1,0 +1,46 @@
+import pytest
+import torch
+
+from emote.nn.layers import Conv1dEncoder
+
+
+def test_conv1denc():
+    bsz = 2
+    channels = 2
+    length = 5
+
+    enc = Conv1dEncoder(
+        input_shape=(channels, length),
+        channels=[channels],
+        kernels=[1],
+        strides=[1],
+        padding=[0],
+        channels_last=False,
+    )
+
+    inp = torch.rand((bsz, channels, length))
+    out = enc(inp)
+
+    # test that the shape of the output matches the calculated one
+    output_size = enc.get_encoder_output_size()  # length of flattened output
+    output_shape = (bsz, output_size)
+    assert out.shape == output_shape
+
+    # test that fails with wrong dimensions
+    inp_wrong_dim = torch.rand((bsz, length + 2, channels))
+    with pytest.raises(
+        RuntimeError,
+        match=".*to have [0-9]+ channels, but got [0-9]+ channels instead$",
+    ):
+        _ = enc(inp_wrong_dim)
+
+    # test that input gets permuted when channels_last = True
+    enc = Conv1dEncoder(
+        input_shape=(length, channels),
+        channels=[channels],
+        kernels=[1],
+        strides=[1],
+        padding=[0],
+        channels_last=True,
+    )
+    assert tuple(enc._input_shape) == (channels, length)


### PR DESCRIPTION
I added a Conv1d encoder which takes as input _(batch size, channels, length)_, or _(batch size, length, channels)_ if `channels_last=True`, following the example of the Con2d encoder. I also added the option to directly add a `nn.Flatten()` layer, instead of having to append one later on, but the _flatten_ parameter can be set to False if needed. 

Also, I updated the existing CURL callback to match the changes done to the Conv2d encoder.