### PR TITLE
Agent proxy that supports multiple input keys

### DIFF
--- a/emote/sac.py
+++ b/emote/sac.py
@@ -436,7 +436,7 @@ class MultiKeyAgentProxy:
             tensor_obs = torch.tensor(np_obs).to(self.device)
             dict_tensor_obs[input_key] = tensor_obs
 
-        actions = self.policy(dict_tensor_obs)[0].detach().cpu().numpy()
+        actions = self.policy(**dict_tensor_obs)[0].detach().cpu().numpy()
 
         return {
             agent_id: DictResponse(list_data={"actions": actions[i]}, scalar_data={})


### PR DESCRIPTION
At the moment, we have agent proxies that support only one input key. These don't support the case of multiple parts in the observation, for example both features and images.

I wrote a new agent proxy that iterates through the given keys and creates a dictionary where all parts of the observation are stored with their respective keys. The policy can then handle these as needed.

Is this a good way to approach this?
