### PR TITLE
Simona/fix logging

### DIFF
--- a/emote/mixins/logging.py
+++ b/emote/mixins/logging.py
@@ -51,7 +51,7 @@ class LoggingMixin:
             # we allow windowed[100]:some_key/foobar to override window size
             if "windowed[" in key:
                 p, k = key.split(":")
-                length = int(key.split("[")[1][:-1])
+                length = int(p.split("[")[1][:-1])
                 key = k
             else:
                 length = self._default_window_length


### PR DESCRIPTION
1. Fixes my own code added in #140 for histogram logging, as it was missing `.items()` to properly iterate through the dictionary when sending to the writer. Also, PyTorch complains about getting a deque as it expects a numpy array, torch tensor, or caffe2 blob name, so now the deque is converted to a numpy array.
2. Fixes wrong key splitting in _log_windowed_scalar_ for overriding the window size.