### PR TITLE
updating the checkpointer and checkpoint loader

### DIFF
--- a/emote/callback.py
+++ b/emote/callback.py
@@ -211,7 +211,7 @@ class Callback(metaclass=CallbackMeta):
     def state_dict(self) -> Dict[str, Any]:
         return {}
 
-    def load_state_dict(self, state_dict: Dict[str, Any]):
+    def load_state_dict(self, state_dict: Dict[str, Any], *args, **kwargs):
         pass
 
 

--- a/emote/callback.py
+++ b/emote/callback.py
@@ -211,7 +211,13 @@ class Callback(metaclass=CallbackMeta):
     def state_dict(self) -> Dict[str, Any]:
         return {}
 
-    def load_state_dict(self, state_dict: Dict[str, Any], *args, **kwargs):
+    def load_state_dict(
+        self,
+        state_dict: Dict[str, Any],
+        load_network: bool = True,
+        load_optimizer: bool = True,
+        load_hparams: bool = True,
+    ):
         pass
 
 

--- a/emote/callbacks/checkpointing.py
+++ b/emote/callbacks/checkpointing.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+import warnings
 
 from typing import List, Optional
 
@@ -14,18 +15,12 @@ from emote.callback import Callback
 class Checkpointer(Callback):
     """Checkpointer writes out a checkpoint every n steps.
 
-    Exactly what is written to the checkpoint is determined by the networks and
-    callbacks supplied in the constructor.
+    Exactly what is written to the checkpoint is determined by the callbacks
+    supplied in the constructor.
 
-    :param callbacks (List[Callback]): A list of callbacks the should be saved.
+    :param callbacks (List[Callback]): A list of callbacks that should be saved.
     :param run_root (str): The root path to where the run artifacts should be stored.
     :param checkpoint_interval (int): Number of backprops between checkpoints.
-    :param optimizers (Optional[List[optim.Optimizer]]): Optional list of optimizers
-        to save. Usually optimizers are handled by their respective callbacks but
-        if you give them to this list they will be handled explicitly.
-    :param networks (Optional[List[nn.Module]]): An optional list of networks that
-        should be saved. Usually networks and optimizers are both restored by the
-        callbacks which handles their parameters.
     :param storage_subdirectory (str): The subdirectory where the checkpoints are
         stored.
     """
@@ -37,28 +32,42 @@ class Checkpointer(Callback):
         run_root: str,
         checkpoint_interval: int,
         checkpoint_index: int = 0,
-        optimizers: Optional[List[optim.Optimizer]] = None,
-        networks: Optional[List[nn.Module]] = None,
         storage_subdirectory: str = "checkpoints",
     ):
         super().__init__(cycle=checkpoint_interval)
-        self._cbs = callbacks
         self._run_root = run_root
         self._checkpoint_index = checkpoint_index
-        self._opts: List[optim.Optimizer] = optimizers if optimizers else []
-        self._nets: List[nn.Module] = networks if networks else []
         self._folder_path = os.path.join(run_root, storage_subdirectory)
+
+        self._cbs = []
+        names = []
+        for cb in callbacks:
+            if hasattr(cb, "name"):
+                self._cbs.append(cb)
+                names.append(cb.name)
+            else:
+                warnings.warn(
+                    f"Checkpointer ignored {cb} because of not "
+                    f"having the 'name' field.",
+                    UserWarning,
+                )
+
+        if len(names) != len(set(names)):
+            raise ValueError(
+                "Checkpointer is given a list of callbacks with at least"
+                "two callbacks with identical names"
+            )
 
     def begin_training(self):
         os.makedirs(self._folder_path, exist_ok=True)
 
     def end_cycle(self):
-        state_dict = {}
-        state_dict["callback_state_dicts"] = [cb.state_dict() for cb in self._cbs]
-        state_dict["network_state_dicts"] = [net.state_dict() for net in self._nets]
-        state_dict["optim_state_dicts"] = [opt.state_dict() for opt in self._opts]
-        state_dict["training_state"] = {
-            "checkpoint_index": self._checkpoint_index,
+
+        state_dict = {
+            "callback_state_dicts": {cb.name: cb.state_dict() for cb in self._cbs},
+            "training_state": {
+                "checkpoint_index": self._checkpoint_index,
+            },
         }
         name = f"checkpoint_{self._checkpoint_index}.tar"
         final_path = os.path.join(self._folder_path, name)
@@ -69,22 +78,19 @@ class Checkpointer(Callback):
 class CheckpointLoader(Callback):
     """CheckpointLoader loads a checkpoint like the one created by Checkpointer.
 
-    This is intended for resuming training given a specific checkpoint index. If you
-    want to do something more specific, like only restore a specific network, it is
-    probably easier to just do it explicitly when the network is constructed.
+    This is intended for resuming training given a specific checkpoint index. It is
+    also possible to only load neural networks.  If you want to do something more
+    specific, like only restore a specific network, it is probably easier to just
+    do it explicitly when the network is constructed.
 
-    :param callbacks (List[Callback]): A list of callbacks the should be restored.
+    :param callbacks (List[Callback]): A list of callbacks that should be restored.
     :param run_root (str): The root path to where the run artifacts should be stored.
     :param checkpoint_index (int): Which checkpoint to load.
     :param reset_training_steps (bool): If True, start training at bp_steps=0 etc.
         Otherwise start the training at whatever step and state the checkpoint has
         saved.
-    :param optimizers (Optional[List[optim.Optimizer]]): Optional list of optimizers
-        to restore. Usually optimizers are handled by their respective callbacks but
-        if you give them to this list they will be handled explicitly.
-    :param networks (Optional[List[nn.Module]]): An optional list of networks that
-        should be restored. Usually networks and optimizers are both restored by the
-        callbacks which handles their parameters.
+    :param only_load_networks (bool): If True, only loads the neural network params
+        inside the callback and skips the rest of them.
     :param storage_subdirectory (str): The subdirectory where the checkpoints are
         stored.
     """
@@ -96,18 +102,34 @@ class CheckpointLoader(Callback):
         run_root: str,
         checkpoint_index: int,
         reset_training_steps: bool = False,
-        optimizers: Optional[List[optim.Optimizer]] = None,
-        networks: Optional[List[nn.Module]] = None,
+        only_load_networks: bool = False,
         storage_subdirectory: str = "checkpoints",
     ):
         super().__init__()
-        self._cbs = callbacks
         self._run_root = run_root
         self._checkpoint_index = checkpoint_index
         self._reset_training_steps = reset_training_steps
-        self._opts: List[optim.Optimizer] = optimizers if optimizers else []
-        self._nets: List[nn.Module] = networks if networks else []
         self._folder_path = os.path.join(run_root, storage_subdirectory)
+
+        self._only_load_networks = only_load_networks
+        self._cbs = []
+        names = []
+        for cb in callbacks:
+            if hasattr(cb, "name"):
+                self._cbs.append(cb)
+                names.append(cb.name)
+            else:
+                warnings.warn(
+                    f"CheckpointLoader ignored {cb} because of not "
+                    f"having the 'name' field.",
+                    UserWarning,
+                )
+
+        if len(names) != len(set(names)):
+            raise ValueError(
+                "CheckpointLoader is given a list of callbacks with at least"
+                "two callbacks with identical names"
+            )
 
     def begin_training(self):
         start_time = time.time()
@@ -119,12 +141,11 @@ class CheckpointLoader(Callback):
         final_path = os.path.join(self._folder_path, name)
         logging.info(f"Loading checkpoints from {self._folder_path}")
         state_dict: dict = torch.load(final_path)
-        for cb, state in zip(self._cbs, state_dict["callback_state_dicts"]):
-            cb.load_state_dict(state)
-        for net, state in zip(self._nets, state_dict["network_state_dicts"]):
-            net.load_state_dict(state)
-        for opt, state in zip(self._opts, state_dict["optim_state_dicts"]):
-            opt.load_state_dict(state)
+
+        for cb in self._cbs:
+            state = state_dict["callback_state_dicts"][cb.name]
+            cb.load_state_dict(state, self._only_load_networks)
+
         return_value = {}
         if not self._reset_training_steps:
             return_value = state_dict.get("training_state", {})

--- a/emote/callbacks/loss.py
+++ b/emote/callbacks/loss.py
@@ -52,11 +52,16 @@ class LossCallback(LoggingMixin, Callback):
             state["network_state_dict"] = self.network.state_dict()
         return state
 
-    def load_state_dict(self, state_dict: Dict[str, Any]):
-        if self.optimizer:
-            self.optimizer.load_state_dict(state_dict.pop("optimizer_state_dict"))
+    def load_state_dict(
+        self, state_dict: Dict[str, Any], only_load_network: bool = False
+    ):
         if self.network:
             self.network.load_state_dict(state_dict.pop("network_state_dict"))
+        if only_load_network:
+            return
+
+        if self.optimizer:
+            self.optimizer.load_state_dict(state_dict.pop("optimizer_state_dict"))
         super().load_state_dict(state_dict)
 
     @Callback.extend

--- a/emote/callbacks/loss.py
+++ b/emote/callbacks/loss.py
@@ -65,8 +65,7 @@ class LossCallback(LoggingMixin, Callback):
         if self.optimizer and load_optimizers:
             self.optimizer.load_state_dict(state_dict.pop("optimizer_state_dict"))
 
-        if load_hparams:
-            super().load_state_dict(state_dict)
+        super().load_state_dict(state_dict, load_weights, load_optimizers, load_hparams)
 
     @Callback.extend
     def loss(self, *args, **kwargs) -> Tensor:

--- a/emote/callbacks/loss.py
+++ b/emote/callbacks/loss.py
@@ -53,16 +53,20 @@ class LossCallback(LoggingMixin, Callback):
         return state
 
     def load_state_dict(
-        self, state_dict: Dict[str, Any], only_load_network: bool = False
+        self,
+        state_dict: Dict[str, Any],
+        load_weights: bool = True,
+        load_optimizers: bool = True,
+        load_hparams: bool = True,
     ):
-        if self.network:
+        if self.network and load_weights:
             self.network.load_state_dict(state_dict.pop("network_state_dict"))
-        if only_load_network:
-            return
 
-        if self.optimizer:
+        if self.optimizer and load_optimizers:
             self.optimizer.load_state_dict(state_dict.pop("optimizer_state_dict"))
-        super().load_state_dict(state_dict)
+
+        if load_hparams:
+            super().load_state_dict(state_dict)
 
     @Callback.extend
     def loss(self, *args, **kwargs) -> Tensor:

--- a/emote/mixins/logging.py
+++ b/emote/mixins/logging.py
@@ -104,14 +104,23 @@ class LoggingMixin:
         state_dict["windowed_scalar_cumulative"] = self.windowed_scalar_cumulative
         return state_dict
 
-    def load_state_dict(self, state_dict: Dict[str, Any]):
-        self.scalar_logs = state_dict.pop("scalar_logs")
-        self.hist_logs = state_dict.pop("hist_logs")
-        self.video_logs = state_dict.pop("video_logs")
-        self.image_logs = state_dict.pop("image_logs")
-        self.windowed_scalar = {
-            k: deque(v[0], maxlen=v[1]) for (k, v) in self.windowed_scalar.items()
-        }
-        self.windowed_scalar_cumulative = state_dict.pop("windowed_scalar_cumulative")
+    def load_state_dict(
+        self,
+        state_dict: Dict[str, Any],
+        load_network: bool = True,
+        load_optimizer: bool = True,
+        load_hparams: bool = True,
+    ):
+        if load_hparams:
+            self.scalar_logs = state_dict.pop("scalar_logs")
+            self.hist_logs = state_dict.pop("hist_logs")
+            self.video_logs = state_dict.pop("video_logs")
+            self.image_logs = state_dict.pop("image_logs")
+            self.windowed_scalar = {
+                k: deque(v[0], maxlen=v[1]) for (k, v) in self.windowed_scalar.items()
+            }
+            self.windowed_scalar_cumulative = state_dict.pop(
+                "windowed_scalar_cumulative"
+            )
 
-        super().load_state_dict(state_dict)
+        super().load_state_dict(state_dict, load_network, load_optimizer, load_hparams)

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -77,7 +77,6 @@ def test_networks_checkpoint():
             callbacks=[loss_cb],
             run_root=run_root,
             checkpoint_index=0,
-            only_load_networks=True,
         ),
         BackPropStepsTerminator(1),
     ]

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -10,6 +10,7 @@ from torch.optim import Adam
 from emote import Trainer
 from emote.callbacks.checkpointing import Checkpointer, CheckpointLoader
 from emote.callbacks.generic import BackPropStepsTerminator
+from emote.callbacks.loss import LossCallback
 from emote.sac import QLoss
 from emote.trainer import TrainingShutdownException
 
@@ -47,9 +48,18 @@ def test_networks_checkpoint():
     chkpt_dir = mkdtemp()
     run_root = join(chkpt_dir, "chkpt")
     n1 = nn.Linear(1, 1)
+    loss_cb = LossCallback(
+        name="linear",
+        optimizer=Adam(n1.parameters(), lr=0.01),
+        network=n1,
+        max_grad_norm=0,
+        data_group="",
+    )
     c1 = [
         Checkpointer(
-            networks=[n1], callbacks=[], run_root=run_root, checkpoint_interval=1
+            callbacks=[loss_cb],
+            run_root=run_root,
+            checkpoint_interval=1,
         )
     ]
 
@@ -64,12 +74,17 @@ def test_networks_checkpoint():
 
     c2 = [
         CheckpointLoader(
-            networks=[n2], callbacks=[], run_root=run_root, checkpoint_index=0
+            callbacks=[loss_cb],
+            run_root=run_root,
+            checkpoint_index=0,
+            only_load_networks=True,
         ),
         BackPropStepsTerminator(1),
     ]
+    n2 = loss_cb.network
     t2 = Trainer(c2, nostep_dataloader())
     t2.train()
+
     assert torch.allclose(n1(test_data), n2(test_data))
 
 
@@ -91,9 +106,7 @@ def test_qloss_checkpoints():
     ql1 = QLoss(name="q", q=q1, opt=Adam(q1.parameters()))
     c1 = [
         ql1,
-        Checkpointer(
-            networks=[], callbacks=[ql1], run_root=run_root, checkpoint_interval=1
-        ),
+        Checkpointer(callbacks=[ql1], run_root=run_root, checkpoint_interval=1),
     ]
 
     t1 = Trainer(c1, random_onestep_dataloader())
@@ -109,9 +122,7 @@ def test_qloss_checkpoints():
     ql2 = QLoss(name="q", q=q2, opt=Adam(q1.parameters()))
     c2 = [
         ql2,
-        CheckpointLoader(
-            networks=[], callbacks=[ql2], run_root=run_root, checkpoint_index=0
-        ),
+        CheckpointLoader(callbacks=[ql2], run_root=run_root, checkpoint_index=0),
     ]
     t2 = Trainer(c2, nostep_dataloader())
     t2.train()


### PR DESCRIPTION
Made some updates to the Checkpointer and Checkpointloader as follows:

* Removed the extra input arguments for loading networks and optimizers. Now, you can only load a list of callbacks. However, added an additional input to the Checkpointloader class. When set to True, this input instructs the loader to exclusively load the neural network parameters, disregarding the state_dict of other callbacks. This feature is useful in scenarios where you need to copy a network from one callback to another or when you prefer not to load other callback parameters.

Both Checkpointer and Checkpointloader rely on a list of callbacks rather than a dictionary. To ensure the correct loading of callbacks, we store a corresponding list of names when saving the checkpoints. These names serve as references during the loading process. The names are loaded from the callback names. Callbacks without a name field are discarded. An error will be raised in case repetitive names are given. 