### PR TITLE
Switch order of checks in log_windowed_scalar

### DIFF
--- a/emote/mixins/logging.py
+++ b/emote/mixins/logging.py
@@ -47,15 +47,15 @@ class LoggingMixin:
         whichever length is found first will be permanent.
         """
 
-        if key not in self.windowed_scalar:
-            # we allow windowed[100]:some_key/foobar to override window size
-            if "windowed[" in key:
-                p, k = key.split(":")
-                length = int(p.split("[")[1][:-1])
-                key = k
-            else:
-                length = self._default_window_length
+        # we allow windowed[100]:some_key/foobar to override window size
+        if "windowed[" in key:
+            p, k = key.split(":")
+            length = int(p.split("[")[1][:-1])
+            key = k
+        else:
+            length = self._default_window_length
 
+        if key not in self.windowed_scalar:
             self.windowed_scalar[key] = deque(maxlen=length)
             self.windowed_scalar_cumulative[key] = 0
 


### PR DESCRIPTION
For keys that override the default window length, we are separating the original key in two parts: the first one which gives us the length, and the second one which is the actual key we want to use for logging in the _windowed_scalar_ dictionary. For example, for a given key "_windowed[100]:**score**_", we will log using the key "_score_".

Next time that same value is sent to the logger, it is sent as "_windowed[100]:score_" again, but that key doesn't exist in the dictionary as we logged it using "_score_". So we enter the if-condition where we split the key, get "_score_" as the key we want to use for logging, and create a new deque with that key overwriting the data contained there previously.

By switching the order of the checks, we first split the key if it contains "_windowed[_" and then check if the obtained key after splitting exists in the dictionary, which then appends the value to the existing deque.

