### PR TITLE
Update windowed scalar (again)

### DIFF
--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -296,7 +296,7 @@ class LoggingProxyWrapper(TableMemoryProxyWrapper, LoggingMixin):
                 k_split = k.split("/")
                 k_split[0] = k_split[0] + "_" + suffix
                 k = "/".join(k_split)
-                
+
             k = k.split(":")[1] if k.startswith("windowed[") else k
 
             self._writer.add_scalar(f"{k}/cumulative", v, inf_step)

--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -287,6 +287,8 @@ class LoggingProxyWrapper(TableMemoryProxyWrapper, LoggingMixin):
                 k_split[0] = k_split[0] + "_" + suffix
                 k = "/".join(k_split)
 
+            k = k.split(":")[1] if k.startswith("windowed[") else k
+
             self._writer.add_scalar(k, sum(v) / len(v), inf_step)
 
         for k, v in self.windowed_scalar_cumulative.items():
@@ -294,6 +296,8 @@ class LoggingProxyWrapper(TableMemoryProxyWrapper, LoggingMixin):
                 k_split = k.split("/")
                 k_split[0] = k_split[0] + "_" + suffix
                 k = "/".join(k_split)
+                
+            k = k.split(":")[1] if k.startswith("windowed[") else k
 
             self._writer.add_scalar(f"{k}/cumulative", v, inf_step)
 

--- a/emote/mixins/logging.py
+++ b/emote/mixins/logging.py
@@ -50,7 +50,7 @@ class LoggingMixin:
         if key not in self.windowed_scalar:
             # we allow windowed[100]:some_key/foobar to override window size
             if "windowed[" in key:
-                p, k = key.split(":")
+                p = key.split(":")[0]
                 length = int(p.split("[")[1][:-1])
             else:
                 length = self._default_window_length

--- a/emote/mixins/logging.py
+++ b/emote/mixins/logging.py
@@ -47,17 +47,16 @@ class LoggingMixin:
         whichever length is found first will be permanent.
         """
 
-        # we allow windowed[100]:some_key/foobar to override window size
-        if "windowed[" in key:
-            p, k = key.split(":")
-            length = int(p.split("[")[1][:-1])
-            key = k
-        else:
-            length = self._default_window_length
-
         if key not in self.windowed_scalar:
-            self.windowed_scalar[key] = deque(maxlen=length)
-            self.windowed_scalar_cumulative[key] = 0
+            # we allow windowed[100]:some_key/foobar to override window size
+            if "windowed[" in key:
+                p, k = key.split(":")
+                length = int(p.split("[")[1][:-1])
+            else:
+                length = self._default_window_length
+
+                self.windowed_scalar[key] = deque(maxlen=length)
+                self.windowed_scalar_cumulative[key] = 0
 
         if isinstance(value, Iterable):
             val = value.numpy() if isinstance(value, torch.Tensor) else value

--- a/emote/mixins/logging.py
+++ b/emote/mixins/logging.py
@@ -55,8 +55,8 @@ class LoggingMixin:
             else:
                 length = self._default_window_length
 
-                self.windowed_scalar[key] = deque(maxlen=length)
-                self.windowed_scalar_cumulative[key] = 0
+            self.windowed_scalar[key] = deque(maxlen=length)
+            self.windowed_scalar_cumulative[key] = 0
 
         if isinstance(value, Iterable):
             val = value.numpy() if isinstance(value, torch.Tensor) else value


### PR DESCRIPTION
After fixing the overwriting problem in #148, I found that by logging using the split key we cause problems in other places where we request data from the dictionary. By the same logic as #148, when we want to get logged data we would request the original key, e.g. "windowed[100]:score" which doesn't exist in the dictionary, so we don't get any value back. Anything that depends on these values is then broken. 

Instead of splitting the key in a bunch of other places, this code uses the original key in the dictionary and then splits it only for logging to the writer.