### PR TITLE
Remove _inf_step from tb logs

### DIFF
--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -273,7 +273,7 @@ class LoggingProxyWrapper(TableMemoryProxyWrapper, LoggingMixin):
                 self.completed_episodes,
             )
 
-        suffix = "inf_step"
+        suffix = False
         for k, v in self.scalar_logs.items():
             if suffix:
                 k_split = k.split("/")


### PR DESCRIPTION
Why do we suffix this with inf-step? It gets very noisy and makes it much harder to compare the graphs between cog and emote. Could we remove it while we're debugging at least?