### PR TITLE
Change check for bias initialization

### DIFF
--- a/emote/nn/initialization.py
+++ b/emote/nn/initialization.py
@@ -9,7 +9,7 @@ def ortho_init_(m, gain=np.sqrt(2)):
         nn.init.constant_(m.bias.data, 0.0)
     if isinstance(m, nn.Conv2d):
         nn.init.orthogonal_(m.weight.data, gain)
-        if m.bias:
+        if m.bias is not None:
             nn.init.constant_(m.bias.data, 0.0)
 
 


### PR DESCRIPTION
The current check raises RuntimeError: Boolean value of Tensor with more than one value is ambiguous