### PR TITLE
add optional per-parameter logging for loss callbacks

### DIFF
--- a/emote/callbacks/loss.py
+++ b/emote/callbacks/loss.py
@@ -1,7 +1,8 @@
 from typing import Any, Dict, Optional
 
-from torch import Tensor, nn, optim
 import torch
+
+from torch import Tensor, nn, optim
 from torch.optim import lr_scheduler
 
 from emote.callback import Callback

--- a/emote/callbacks/loss.py
+++ b/emote/callbacks/loss.py
@@ -70,13 +70,10 @@ class LossCallback(LoggingMixin, Callback):
         for name, parameter in self._named_parameters.items():
             split = name.split(".")
             log_name = self.name + "_" + "_".join(split[:-1])
-
-            p_shape = _friendly_shape_str(parameter.shape)
-            g_shape = _friendly_shape_str(parameter.grad.shape)
-
             param_type = split[-1]
 
-            if self._log_per_param_grads:
+            if self._log_per_param_grads and parameter.grad is not None:
+                g_shape = _friendly_shape_str(parameter.grad.shape)
                 self.log_histogram(
                     f"{param_type}_grads/{log_name}_{g_shape}", parameter.grad
                 )
@@ -86,6 +83,7 @@ class LossCallback(LoggingMixin, Callback):
                 )
 
             if self._log_per_param_weights:
+                p_shape = _friendly_shape_str(parameter.shape)
                 self.log_histogram(f"{param_type}/{log_name}_{p_shape}", parameter)
                 self.log_scalar(
                     f"{param_type}_l2/{log_name}_{p_shape}", torch.norm(parameter, p=2)

--- a/emote/callbacks/loss.py
+++ b/emote/callbacks/loss.py
@@ -9,6 +9,10 @@ from emote.callback import Callback
 from emote.mixins.logging import LoggingMixin
 
 
+def _friendly_size_str(size: torch.Size):
+    return str(list(size)).replace("[", "").replace("]", "").replace(", ", "_")
+
+
 class LossCallback(LoggingMixin, Callback):
     """Losses are callbacks that implement a *loss function*."""
 
@@ -65,16 +69,13 @@ class LossCallback(LoggingMixin, Callback):
             self.log_per_param_weights_and_grads()
 
     def log_per_param_weights_and_grads(self):
-        def _friendly_shape_str(shape):
-            return str(list(shape)).replace("[", "").replace("]", "").replace(", ", "_")
-
         for name, parameter in self._named_parameters.items():
             split = name.split(".")
             log_name = self.name + "_" + "_".join(split[:-1])
             param_type = split[-1]
 
             if self._log_per_param_grads and parameter.grad is not None:
-                g_shape = _friendly_shape_str(parameter.grad.shape)
+                g_shape = _friendly_size_str(parameter.grad.shape)
                 self.log_histogram(
                     f"{param_type}_grads/{log_name}_{g_shape}", parameter.grad
                 )
@@ -84,7 +85,7 @@ class LossCallback(LoggingMixin, Callback):
                 )
 
             if self._log_per_param_weights:
-                p_shape = _friendly_shape_str(parameter.shape)
+                p_shape = _friendly_size_str(parameter.shape)
                 self.log_histogram(f"{param_type}/{log_name}_{p_shape}", parameter)
                 self.log_scalar(
                     f"{param_type}_l2/{log_name}_{p_shape}", torch.norm(parameter, p=2)

--- a/emote/callbacks/loss.py
+++ b/emote/callbacks/loss.py
@@ -61,7 +61,8 @@ class LossCallback(LoggingMixin, Callback):
         self.log_scalar(f"loss/{self.name}_loss", loss)
         self.log_scalar(f"loss/{self.name}_gradient_norm", grad_norm)
 
-        self.log_per_param_weights_and_grads()
+        if self._log_per_param_weights or self._log_per_param_grads:
+            self.log_per_param_weights_and_grads()
 
     def log_per_param_weights_and_grads(self):
         def _friendly_shape_str(shape):

--- a/emote/sac.py
+++ b/emote/sac.py
@@ -37,6 +37,8 @@ class QLoss(LossCallback):
         for the optimizer of q.
     :param max_grad_norm (float): Clip the norm of the gradient during backprop using this value.
     :param data_group (str): The name of the data group from which this Loss takes its data.
+    :param log_per_param_weights (bool): If true, log each individual policy parameter that is optimized (norm and value histogram).
+    :param log_per_param_grads (bool): If true, log the gradients of each individual policy parameter that is optimized (norm and histogram).
     """
 
     def __init__(
@@ -48,6 +50,8 @@ class QLoss(LossCallback):
         lr_schedule: Optional[optim.lr_scheduler._LRScheduler] = None,
         max_grad_norm: float = 10.0,
         data_group: str = "default",
+        log_per_param_weights=False,
+        log_per_param_grads=False,
     ):
         super().__init__(
             name=name,
@@ -56,6 +60,8 @@ class QLoss(LossCallback):
             network=q,
             max_grad_norm=max_grad_norm,
             data_group=data_group,
+            log_per_param_weights=log_per_param_weights,
+            log_per_param_grads=log_per_param_grads,
         )
         self.q_network = q
         self.mse = nn.MSELoss()
@@ -170,6 +176,8 @@ class PolicyLoss(LossCallback):
     :param max_grad_norm (float): Clip the norm of the gradient during backprop using this value.
     :param name (str): The name of the module. Used e.g. while logging.
     :param data_group (str): The name of the data group from which this Loss takes its data.
+    :param log_per_param_weights (bool): If true, log each individual policy parameter that is optimized (norm and value histogram).
+    :param log_per_param_grads (bool): If true, log the gradients of each individual policy parameter that is optimized (norm and histogram).
     """
 
     def __init__(
@@ -184,6 +192,8 @@ class PolicyLoss(LossCallback):
         max_grad_norm: float = 10.0,
         name: str = "policy",
         data_group: str = "default",
+        log_per_param_weights=False,
+        log_per_param_grads=False,
     ):
         super().__init__(
             name=name,
@@ -192,6 +202,8 @@ class PolicyLoss(LossCallback):
             network=pi,
             max_grad_norm=max_grad_norm,
             data_group=data_group,
+            log_per_param_weights=log_per_param_weights,
+            log_per_param_grads=log_per_param_grads,
         )
         self.policy = pi
         self._ln_alpha = ln_alpha


### PR DESCRIPTION
This PR adds the ability to log per-parameter information, similar to what we had in Cog. It is opt-in and off by default.

See attached screenshot for examples of how it can look like.
![per_param](https://github.com/EmbarkStudios/emote/assets/6956114/bf3d7f83-b17e-4657-9011-5ce662d9ef57)
