### PR TITLE
setup multi-python image

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -23,6 +23,12 @@ RUN curl https://pyenv.run | bash && \
 	python --version && \
 	pyenv exec pip --version
 
+RUN mkdir -p /gcloud/ && \
+	curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-408.0.1-linux-x86_64.tar.gz && \
+	tar -xf google-cloud-cli-408.0.1-linux-x86_64.tar.gz -C /gcloud/ && \
+	/gcloud/google-cloud-sdk/install.sh --quiet --usage-reporting false && \
+	rm google-cloud-cli-408.0.1-linux-x86_64.tar.gz
+
 RUN eval "$(pyenv init --path)" && \
 	eval "$(pyenv init -)" && \
 	pyenv global 3.11 && python --version && python -m pip install \

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,34 +1,44 @@
-FROM docker.io/python@sha256:832385dfbafed97b56379fa2665f858d9178f8fea4bc6efc8d3282804d68a6b4
+FROM docker.io/buildpack-deps:22.04-curl
 
 ENV PYTHONUNBUFFERED=1 \
 	PYTHONDONTWRITEBYTECODE=1 \
 	PIP_NO_CACHE_DIR=off \
 	PIP_DISABLE_PIP_VERSION_CHECK=on \
 	PIP_DEFAULT_TIMEOUT=100 \
-	PATH="$PATH:/root/.local/bin/"
+	PATH="$PATH:/root/.local/bin/:/.pyenv/bin/" \
+	PYENV_ROOT="/.pyenv"
 
 RUN apt-get -y update && \
-    apt-get -y install curl build-essential gcc git swig && \
+    apt-get -y install curl build-essential gcc git swig libffi-dev libncurses5-dev zlib1g zlib1g-dev libssl-dev libsqlite3-dev liblzma-dev libreadline-dev libbz2-dev && \
     apt-get -y clean
 
-RUN mkdir -p /gcloud/ && \
-	curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-408.0.1-linux-x86_64.tar.gz && \
-	tar -xf google-cloud-cli-408.0.1-linux-x86_64.tar.gz -C /gcloud/ && \
-	/gcloud/google-cloud-sdk/install.sh --quiet --usage-reporting false && \
-	rm google-cloud-cli-408.0.1-linux-x86_64.tar.gz
+RUN curl https://pyenv.run | bash && \
+	eval "$(pyenv init -)" && \
+	pyenv install 3.11 && \
+	pyenv global 3.11 && \
+	pyenv install 3.10 && \
+	pyenv install 3.9 && \
+	pyenv install 3.8 && \
+	pyenv rehash && \
+	python --version && \
+	pyenv exec pip --version
 
-RUN pip install \
-	--no-cache-dir \
-	pipx && \
+RUN eval "$(pyenv init --path)" && \
+	eval "$(pyenv init -)" && \
+	pyenv global 3.11 && python --version && python -m pip install \
+	--no-cache-dir pipx && \
+	pyenv rehash && \
 	pipx install --pip-args='--no-cache-dir' pdm~=2.3.0 --suffix 23 && \
 	pipx install --pip-args='--no-cache-dir' pdm~=2.4.0 --suffix 24 && \
 	pipx install --pip-args='--no-cache-dir' pdm~=2.5.0 --suffix 25 && \
 	pipx install --pip-args='--no-cache-dir' pdm~=2.6.0 --suffix 26 && \
 	pipx install --pip-args='--no-cache-dir' pdm~=2.7.0 --suffix 27 && \
+	pipx install --pip-args='--no-cache-dir' pdm~=2.7.0 --suffix 28 && \
 	pdm23 --version && \
 	pdm24 --version && \
 	pdm25 --version && \
 	pdm26 --version && \
-	pdm27 --version
+	pdm27 --version && \
+	pdm28 --version
 
 ENTRYPOINT bash

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -39,7 +39,7 @@ RUN eval "$(pyenv init --path)" && \
 	pipx install --pip-args='--no-cache-dir' pdm~=2.5.0 --suffix 25 && \
 	pipx install --pip-args='--no-cache-dir' pdm~=2.6.0 --suffix 26 && \
 	pipx install --pip-args='--no-cache-dir' pdm~=2.7.0 --suffix 27 && \
-	pipx install --pip-args='--no-cache-dir' pdm~=2.7.0 --suffix 28 && \
+	pipx install --pip-args='--no-cache-dir' pdm~=2.8.0 --suffix 28 && \
 	pdm23 --version && \
 	pdm24 --version && \
 	pdm25 --version && \

--- a/.buildkite/install-repo.sh
+++ b/.buildkite/install-repo.sh
@@ -7,6 +7,10 @@ gcloud config set account monorepo-ci@embark-builds.iam.gserviceaccount.com
 
 echo --- Installing dependencies
 
+eval "$(pyenv init --path)"
+eval "$(pyenv init -)"
+
+${PDM_COMMAND:1:-1} use ${PYTHON_VERSION:1:-1}
 ${PDM_COMMAND:1:-1} install -d -G ci -k post_install
 ${PDM_COMMAND:1:-1} plugin add pdm-plugin-torch>=23.1.1
 ${PDM_COMMAND:1:-1} torch install cpu

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,7 +39,7 @@ large: &large
 
 env:
   PDM_COMMAND: pdm25
-  PYTHON_VERSION: '3.8'
+  PYTHON_VERSION: '3.9'
 
 steps:
   - group: ":passport_control: Validating PR"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 plugin_base: &plugin_base
     service-account-name: monorepo-ci
-    image: gcr.io/embark-shared/ml/ci-runner@sha256:c48501865482a725e3f5ef947b84dfd448d286f8a12c108ab32e22f82abb407b
+    image: gcr.io/embark-shared/ml/ci-runner@sha256:230b844ee23cc307031e2ceb62eafc8c53af7df8f865880675f832137453b0fc
     default-secret-name: buildkite-k8s-plugin
     always-pull: false
     use-agent-node-affinity: true
@@ -39,6 +39,7 @@ large: &large
 
 env:
   PDM_COMMAND: pdm25
+  PYTHON_VERSION: '3.8'
 
 steps:
   - group: ":passport_control: Validating PR"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 plugin_base: &plugin_base
     service-account-name: monorepo-ci
-    image: gcr.io/embark-shared/ml/ci-runner@sha256:230b844ee23cc307031e2ceb62eafc8c53af7df8f865880675f832137453b0fc
+    image: gcr.io/embark-shared/ml/ci-runner@sha256:3a40865ba39ce1a1a39892b4d6128adb7d802e6cd20407246fea87d97ffae218
     default-secret-name: buildkite-k8s-plugin
     always-pull: false
     use-agent-node-affinity: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 plugin_base: &plugin_base
     service-account-name: monorepo-ci
-    image: gcr.io/embark-shared/ml/ci-runner@sha256:3a40865ba39ce1a1a39892b4d6128adb7d802e6cd20407246fea87d97ffae218
+    image: gcr.io/embark-shared/ml/ci-runner@sha256:54904440250d9ae14f6ddf6d72c577f2e06c85f79aa6ebe31558c35cbb93280f
     default-secret-name: buildkite-k8s-plugin
     always-pull: false
     use-agent-node-affinity: true

--- a/.buildkite/publish-docs.sh
+++ b/.buildkite/publish-docs.sh
@@ -6,6 +6,9 @@ source .buildkite/install-repo.sh
 echo --- Building docs
 pushd docs
 EXIT_CODE=0
+
+export TZ=UTC
+
 PDM=${PDM_COMMAND:1:-1} ${PDM_COMMAND:1:-1} run make deploy  || EXIT_CODE=$?
 
 if [ $EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
Updates the base CI runner image to use pyenv to provide multiple python version using pyenv. 

This should allow us to reuse this image for all our repositories. See `install-repo.sh` for how to initialize pyenv and select a Python version.