### PR TITLE
Make MemoryProxyWrappers forward methods to wrapee if they do not exist on wrapper

### DIFF
--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -182,7 +182,9 @@ class MemoryProxyWrapper:
         # we only want the memory proxy wrapper to forward methods.
         if not inspect.ismethod(attr):
             raise AttributeError(
-                f"Accessing non-method inner attribute {name} is not allowed."
+                f"Accessing non-method inner attribute {name} is not allowed.",
+                obj=self,
+                name=f"{name}",
             )
 
         return attr

--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -181,10 +181,10 @@ class MemoryProxyWrapper:
         # for some safety, make sure it is an method.
         # we only want the memory proxy wrapper to forward methods.
         if not inspect.ismethod(attr):
+            # NOTE: In python >= 3.10 we should specify
+            # 'obj' and 'name' on the AttributeError so Python can provide hints to the user.
             raise AttributeError(
                 f"Accessing non-method inner attribute {name} is not allowed.",
-                obj=self,
-                name=f"{name}",
             )
 
         return attr

--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -169,7 +169,8 @@ class MemoryProxyWrapper:
     MemoryProxy or MemoryProxyWrapper.
     """
 
-    def __init__(self, inner: "MemoryProxyWrapper" | MemoryProxy):
+    def __init__(self, inner: "MemoryProxyWrapper" | MemoryProxy, **kwargs):
+        super().__init__(**kwargs)
         self._inner = inner
 
     def __getattr__(self, name):
@@ -188,14 +189,14 @@ class MemoryProxyWrapper:
 
 
 class TableMemoryProxyWrapper(MemoryProxyWrapper):
-    def __init__(self, inner: TableMemoryProxy):
-        super().__init__(inner=inner)
+    def __init__(self, *, inner: TableMemoryProxy, **kwargs):
+        super().__init__(inner=inner, **kwargs)
 
     def store(self, path: str):
         return self._inner.store(path)
 
 
-class LoggingProxyWrapper(LoggingMixin, TableMemoryProxyWrapper):
+class LoggingProxyWrapper(TableMemoryProxyWrapper, LoggingMixin):
     def __init__(
         self,
         inner: TableMemoryProxy,

--- a/tests/test_memory_proxy_wrapper.py
+++ b/tests/test_memory_proxy_wrapper.py
@@ -1,0 +1,80 @@
+import pytest
+
+from emote.memory.memory import MemoryProxyWrapper
+
+
+class DummyMemoryProxy:
+    def __init__(self):
+        self.my_attribute = "hello!"
+
+    def say_hello(self):
+        return "hello world"
+
+
+class EmptyMemoryProxyWrapper(MemoryProxyWrapper):
+    def __init__(self, inner):
+        super().__init__(inner)
+
+
+class SayHelloMemoryProxyWrapper(MemoryProxyWrapper):
+    def __init__(self, inner):
+        super().__init__(inner)
+
+    def say_hello(self):
+        return "not hello world"
+
+
+class SayGoodbyeProxyWrapper(MemoryProxyWrapper):
+    def __init__(self, inner):
+        super().__init__(inner)
+
+    def say_goodbye(self):
+        return "goodbye"
+
+
+def test_call_nonexisting_method_on_wrapper_calls_inner():
+    dummy = DummyMemoryProxy()
+    wrapper = EmptyMemoryProxyWrapper(dummy)
+
+    assert (
+        wrapper.say_hello == dummy.say_hello
+    ), "Expected wrapper to forward non-existing method to inner."
+
+
+def test_call_existing_method_on_wrapper_calls_existing():
+    dummy = DummyMemoryProxy()
+    wrapper = SayHelloMemoryProxyWrapper(dummy)
+
+    assert (
+        wrapper.say_hello == wrapper.say_hello
+    ), "Expected wrapper to always use existing method if it exist."
+
+
+def test_chained_wrappers():
+    dummy = DummyMemoryProxy()
+    wrapper1 = SayHelloMemoryProxyWrapper(dummy)
+    wrapper2 = SayGoodbyeProxyWrapper(wrapper1)
+    wrapper3 = EmptyMemoryProxyWrapper(wrapper2)
+
+    assert (
+        wrapper3.say_hello == wrapper1.say_hello
+    ), "Expected wrapper to be able to chain inner forwards."
+    assert (
+        wrapper3.say_goodbye == wrapper2.say_goodbye
+    ), "Expected wrapper to be able to chain inner forwards."
+
+
+def test_wrapper_disallows_accessing_non_method():
+    dummy = DummyMemoryProxy()
+    wrapper = EmptyMemoryProxyWrapper(dummy)
+
+    with pytest.raises(AttributeError):
+        wrapper.my_attribute
+
+
+def test_wrapper_disallows_accessing_non_existing_attribute():
+    dummy = DummyMemoryProxy()
+    wrapper = EmptyMemoryProxyWrapper(dummy)
+
+    with pytest.raises(AttributeError):
+        wrapper.i_do_not_exist

--- a/tests/test_memory_proxy_wrapper.py
+++ b/tests/test_memory_proxy_wrapper.py
@@ -12,8 +12,7 @@ class DummyMemoryProxy:
 
 
 class EmptyMemoryProxyWrapper(MemoryProxyWrapper):
-    def __init__(self, inner):
-        super().__init__(inner)
+    pass
 
 
 class SayHelloMemoryProxyWrapper(MemoryProxyWrapper):


### PR DESCRIPTION
This PR adds a `MemoryProxyWrapper` base class that all memory proxy wrappers should inherit from. This base class takes care of forwarding method calls that do not exist on the wrapper to the inner wrapped object. This solves problems where one would like to call a method existing on some inner wrapee but not on the outermost wrapper itself.