### PR TITLE
Add "latest_checkpoint" path to state_dict

### DIFF
--- a/emote/callbacks/checkpointing.py
+++ b/emote/callbacks/checkpointing.py
@@ -74,8 +74,8 @@ class Checkpointer(Callback):
         self._checkpoint_index += 1
 
         subset = {
-            key: value for key, value in state_dict["training_state"].items()
-            if key not in ["bp_step", "bp_samples"]
+            "latest_checkpoint": state_dict["training_state"]["latest_checkpoint"],
+            "checkpoint_index": state_dict["training_state"]["checkpoint_index"]
         }
         return subset
 

--- a/emote/callbacks/checkpointing.py
+++ b/emote/callbacks/checkpointing.py
@@ -75,7 +75,7 @@ class Checkpointer(Callback):
 
         return {
             "latest_checkpoint": state_dict["training_state"]["latest_checkpoint"],
-            "checkpoint_index": state_dict["training_state"]["checkpoint_index"]
+            "checkpoint_index": state_dict["training_state"]["checkpoint_index"],
         }
 
 

--- a/emote/callbacks/checkpointing.py
+++ b/emote/callbacks/checkpointing.py
@@ -66,7 +66,7 @@ class Checkpointer(Callback):
             "callback_state_dicts": {cb.name: cb.state_dict() for cb in self._cbs},
             "training_state": {
                 "latest_checkpoint": final_path,
-                "checkpoint_index": self._checkpoint_index - 1,
+                "checkpoint_index": self._checkpoint_index,
             },
         }
         torch.save(state_dict, final_path)

--- a/emote/callbacks/checkpointing.py
+++ b/emote/callbacks/checkpointing.py
@@ -72,7 +72,12 @@ class Checkpointer(Callback):
         }
         torch.save(state_dict, final_path)
         self._checkpoint_index += 1
-        return state_dict
+
+        subset = {
+            key: value for key, value in state_dict["training_state"].items()
+            if key not in ["bp_step", "bp_samples"]
+        }
+        return subset
 
 
 class CheckpointLoader(Callback):

--- a/emote/callbacks/checkpointing.py
+++ b/emote/callbacks/checkpointing.py
@@ -61,14 +61,15 @@ class Checkpointer(Callback):
 
     def end_cycle(self):
 
+        name = f"checkpoint_{self._checkpoint_index}.tar"
+        final_path = os.path.join(self._folder_path, name)
         state_dict = {
             "callback_state_dicts": {cb.name: cb.state_dict() for cb in self._cbs},
             "training_state": {
+                "latest_checkpoint": final_path,
                 "checkpoint_index": self._checkpoint_index,
             },
         }
-        name = f"checkpoint_{self._checkpoint_index}.tar"
-        final_path = os.path.join(self._folder_path, name)
         torch.save(state_dict, final_path)
         self._checkpoint_index += 1
 

--- a/emote/callbacks/checkpointing.py
+++ b/emote/callbacks/checkpointing.py
@@ -71,6 +71,7 @@ class Checkpointer(Callback):
         }
         torch.save(state_dict, final_path)
         self._checkpoint_index += 1
+        return state_dict
 
 
 class CheckpointLoader(Callback):

--- a/emote/callbacks/checkpointing.py
+++ b/emote/callbacks/checkpointing.py
@@ -73,11 +73,10 @@ class Checkpointer(Callback):
         torch.save(state_dict, final_path)
         self._checkpoint_index += 1
 
-        subset = {
+        return {
             "latest_checkpoint": state_dict["training_state"]["latest_checkpoint"],
             "checkpoint_index": state_dict["training_state"]["checkpoint_index"]
         }
-        return subset
 
 
 class CheckpointLoader(Callback):

--- a/emote/callbacks/checkpointing.py
+++ b/emote/callbacks/checkpointing.py
@@ -60,14 +60,13 @@ class Checkpointer(Callback):
         os.makedirs(self._folder_path, exist_ok=True)
 
     def end_cycle(self):
-
         name = f"checkpoint_{self._checkpoint_index}.tar"
         final_path = os.path.join(self._folder_path, name)
         state_dict = {
             "callback_state_dicts": {cb.name: cb.state_dict() for cb in self._cbs},
             "training_state": {
                 "latest_checkpoint": final_path,
-                "checkpoint_index": self._checkpoint_index,
+                "checkpoint_index": self._checkpoint_index - 1,
             },
         }
         torch.save(state_dict, final_path)

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -71,7 +71,7 @@ def test_networks_checkpoint():
     n2 = nn.Linear(1, 1)
     test_data = torch.rand(5, 1)
 
-    assert "latest_checkpoint" in t1.state["training_state"]
+    assert "latest_checkpoint" in t1.state
     assert not torch.allclose(n1(test_data), n2(test_data))
 
     c2 = [

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -70,6 +70,8 @@ def test_networks_checkpoint():
     t1.train()
     n2 = nn.Linear(1, 1)
     test_data = torch.rand(5, 1)
+
+    assert "latest_checkpoint" in t1.state["training_state"]
     assert not torch.allclose(n1(test_data), n2(test_data))
 
     c2 = [


### PR DESCRIPTION
Doesn't quite mirror [this cog PR](https://github.com/EmbarkStudios/cog/pull/731/files), but ensures we have the path, as discussed with @tgolsson. Please let me know in case I misunderstood something.