### PR TITLE
split state restoration from begin_training

### DIFF
--- a/docs/callback.rst
+++ b/docs/callback.rst
@@ -11,7 +11,7 @@ inspired by that system - but adapted for RL and our use-cases.
 The `Callback` interface
 ########################
 
-The callback is the core interface used to hook into the Emote framework. You can think of these as events - when the training loop starts, we'll invoke `begin_training` on all callback objects. Then we'll start a new cycle, and call :meth:`Callback.begin_cycle`.
+The callback is the core interface used to hook into the Emote framework. You can think of these as events - when the training loop starts, we'll invoke `begin_training` on all callback objects. Then we'll start a new cycle, and call :meth:`Callback.begin_cycle` for those that need it.
 
 All in all, the flow of callbacks is like this:
 
@@ -20,11 +20,12 @@ All in all, the flow of callbacks is like this:
     digraph foo {
       rankdir=LR;
       node [shape=rectangle,style="rounded"]
-	  
+
       newrank=true;
       { rank=same;  begin_cycle;  begin_batch; }
       { rank=same;  end_batch; end_cycle; }
-	  
+
+	  restore_state;
       begin_training;
       subgraph cluster_cycle {
         label = "while cycles left"
@@ -39,8 +40,8 @@ All in all, the flow of callbacks is like this:
         end_cycle;
       }
 	  end_training;
-	  
-      begin_training -> begin_cycle -> begin_batch -> backward -> end_batch;
+
+      restore_state -> begin_training -> begin_cycle -> begin_batch -> backward -> end_batch;
 
       end_batch -> begin_batch [constraint=no];
       end_cycle -> begin_cycle [constraint=no];

--- a/emote/callback.py
+++ b/emote/callback.py
@@ -108,6 +108,7 @@ class CallbackMeta(ABCMeta):
                 if inspect.isfunction(method)
                 and field
                 in [
+                    "restore_state",
                     "begin_training",
                     "begin_cycle",
                     "begin_batch",
@@ -167,12 +168,11 @@ class CallbackMeta(ABCMeta):
 class Callback(metaclass=CallbackMeta):
     """The principal modular building block of emote.
 
-    Callbacks are modular pieces of code that together build up the training loop.
-    They contain hooks that are executed at different points during training.
-    These can consume values from other callbacks, and generate their own for others
-    to consume. This allows a very loosely coupled flow of data between different
-    parts of the code. The most important examples of callbacks in emote are the
-    Losses.
+    Callbacks are modular pieces of code that together build up the training loop.  They contain
+    hooks that are executed at different points during training.  These can consume values from
+    other callbacks, and generate their own for others to consume. This allows a very loosely
+    coupled flow of data between different parts of the code. The most important examples of
+    callbacks in emote are the Losses.
 
     The concept has been borrowed from Keras and FastAI.
     """
@@ -182,9 +182,15 @@ class Callback(metaclass=CallbackMeta):
         self._order = 0
         self.cycle = cycle
 
+    def restore_state(self, *args, **kwargs):
+        """Called before training starts to allow loader modules to import state. At this point, no
+        assumptions can be made for other modules state.
+
+        """
+        pass
+
     def begin_training(self, *args, **kwargs):
-        """Called when training starts, both from scratch and when restoring
-        from a checkpoint."""
+        """Called when training starts, both from scratch and when restoring from a checkpoint."""
         pass
 
     def begin_cycle(self, *args, **kwargs):
@@ -192,21 +198,27 @@ class Callback(metaclass=CallbackMeta):
         pass
 
     def begin_batch(self, *args, **kwargs):
+        """Called at the start of each batch, immediately after data has been sampled."""
         pass
 
     def backward(self, *args, **kwargs):
+        """The main batch processing should happen here."""
         pass
 
     def end_batch(self, *args, **kwargs):
+        """Called when the backward pass has been completed."""
         pass
 
     def end_cycle(self, *args, **kwargs):
+        """Called when a callbacks cycle is completed."""
         pass
 
     def end_training(self, *args, **kwargs):
+        """Called right before shutdown, if possible."""
         pass
 
     def state_dict(self) -> Dict[str, Any]:
+        """Called by checkpointers primarily to capture state for on-disk saving."""
         return {}
 
     def load_state_dict(
@@ -216,6 +228,7 @@ class Callback(metaclass=CallbackMeta):
         load_optimizer: bool = True,
         load_hparams: bool = True,
     ):
+        """Called from checkpoint-loaders during the `restore_state` phase, primarily."""
         pass
 
 

--- a/emote/callbacks/checkpointing.py
+++ b/emote/callbacks/checkpointing.py
@@ -58,10 +58,12 @@ class Checkpointer(Callback):
     def begin_training(self):
         os.makedirs(self._folder_path, exist_ok=True)
 
-    def end_cycle(self):
+    def end_cycle(self, bp_step, bp_samples):
         state_dict = {
             "callback_state_dicts": {cb.name: cb.state_dict() for cb in self._cbs},
             "training_state": {
+                "bp_step": bp_step,
+                "bp_samples": bp_samples,
                 "checkpoint_index": self._checkpoint_index,
             },
         }
@@ -128,7 +130,7 @@ class CheckpointLoader(Callback):
                 "two callbacks with identical names"
             )
 
-    def begin_training(self):
+    def restore_state(self):
         start_time = time.time()
         if not os.path.exists(self._folder_path):
             raise InvalidCheckpointLocation(

--- a/emote/callbacks/logging.py
+++ b/emote/callbacks/logging.py
@@ -24,8 +24,14 @@ class TensorboardLogger(Callback):
         self._writer = writer
         self._log_samples = log_by_samples
 
-    def begin_training(self):
+        self._bp_samples_at_start = 0
+        self._bp_step_at_start = 0
+
+    def begin_training(self, bp_step, bp_samples):
         self._start_time = time.monotonic()
+
+        self._bp_samples_at_start = bp_samples
+        self._bp_step_at_start = bp_step
 
     def end_cycle(self, bp_step, bp_samples):
         suffix = "bp_step"
@@ -71,9 +77,16 @@ class TensorboardLogger(Callback):
 
         time_since_start = time.monotonic() - self._start_time
         self._writer.add_scalar(
-            "performance/bp_samples_per_sec", bp_samples / time_since_start, bp_step
+            "performance/bp_samples_per_sec",
+            (bp_samples - self._bp_samples_at_start) / time_since_start,
+            bp_step,
         )
-        self._writer.add_scalar("performance/bp_steps_per_sec", bp_step / time_since_start, bp_step)
+
+        self._writer.add_scalar(
+            "performance/bp_steps_per_sec",
+            (bp_step - self._bp_step_at_start) / time_since_start,
+            bp_step,
+        )
 
         self._writer.flush()
 

--- a/emote/memory/callbacks.py
+++ b/emote/memory/callbacks.py
@@ -22,7 +22,7 @@ class MemoryImporterCallback(Callback):
         self._load_fname_override = load_fname_override
         self._load_dir = experiment_load_dir
 
-    def begin_training(self):
+    def restore_state(self):
         if self._load_fname_override not in (None, ""):
             restore_path = os.path.join(self._load_dir, self._load_fname_override)
         else:


### PR DESCRIPTION
This ensures there's no specific ordering required between modules in begin_training, a bug and/or footgun in our old frameworks.
