### PR TITLE
Add a joint memory loader capable of sampling data from multiple memory loaders

### DIFF
--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -464,15 +464,10 @@ class MemoryLoader:
 
 
 class JointMemoryLoader:
-    """A memory loader capable of loading data from multiple `MemoryLoader`s.
+    """A memory loader capable of loading data from multiple `MemoryLoader`s."""
 
-    If a datagroup is specified via the `data_group` param, it will place all loaded data in the specified datagroup,
-    otherwise it will directly return the data fetched from each individual loader.
-    """
-
-    def __init__(self, loaders: list[MemoryLoader], data_group: str | None = None):
+    def __init__(self, loaders: list[MemoryLoader]):
         self._loaders = loaders
-        self._data_group = data_group
 
     def is_ready(self):
         return all(loader.is_ready() for loader in self._loaders)
@@ -489,10 +484,18 @@ class JointMemoryLoader:
             for loader in self._loaders:
                 out.update(next(iter(loader)))
 
-            if self._data_group is not None:
-                out = {self._data_group: out}
-
             yield out
+
+
+class JointMemoryLoaderWithDataGroup(JointMemoryLoader):
+    """A JointMemoryLoader that places its data inside of a user-specified datagroup."""
+
+    def __init__(self, loaders: list[MemoryLoader], data_group: str):
+        super().__init__(loaders)
+        self._data_group = data_group
+
+    def __iter__(self):
+        yield {self._data_group: next(super().__iter__())}
 
 
 class MemoryWarmup(Callback):

--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -475,7 +475,7 @@ class JointMemoryLoader:
         self._data_group = data_group
 
     def is_ready(self):
-        return all([loader.is_ready() for loader in self._loaders])
+        return all(loader.is_ready() for loader in self._loaders)
 
     def __iter__(self):
         if not self.is_ready():

--- a/emote/memory/memory.py
+++ b/emote/memory/memory.py
@@ -471,11 +471,10 @@ class JointMemoryLoader:
         self._loaders = loaders
         self._size_key = size_key
 
-        datagroups = (loader.data_group for loader in loaders)
-        counts = collections.Counter(datagroups)
+        counts = collections.Counter((loader.data_group for loader in loaders))
         counts_over_1 = {k: count for k, count in counts.items() if count > 1}
         if len(counts_over_1) != 0:
-            raise Exception(
+            raise ValueError(
                 f"""JointMemoryLoader was provided MemoryLoaders that share the same datagroup. This will clobber the joint output data and is not allowed.
                 Here is a dict of each datagroup encountered more than once, and its occurance count: {counts_over_1}"""
             )
@@ -485,7 +484,7 @@ class JointMemoryLoader:
 
     def __iter__(self):
         if not self.is_ready():
-            raise Exception(
+            raise RuntimeError(
                 """memory loader(s) in JointMemoryLoader does not have enough data. Check `is_ready()`
                 before trying to iterate over data."""
             )

--- a/tests/test_memory_loading.py
+++ b/tests/test_memory_loading.py
@@ -50,9 +50,7 @@ def another_dummy_table():
     return tab
 
 
-def test_joint_memory_loader(
-    a_dummy_table: ArrayTable, another_dummy_table: ArrayTable
-):
+def test_joint_memory_loader(a_dummy_table: ArrayTable, another_dummy_table: ArrayTable):
     a_loader = MemoryLoader(
         table=a_dummy_table,
         rollout_count=1,
@@ -103,3 +101,23 @@ def test_joint_memory_loader_datagroup(a_dummy_table: ArrayTable, another_dummy_
     assert (
         "a" in data and "another" in data
     ), "Expected joint dataloader to actually place data in its datagroup, but it is empty."
+
+
+def test_joint_memory_loader_nonunique_loaders_trigger_exception(a_dummy_table: ArrayTable):
+    loader1 = MemoryLoader(
+        table=a_dummy_table,
+        rollout_count=1,
+        rollout_length=1,
+        size_key="batch_size",
+        data_group="a",
+    )
+    loader2 = MemoryLoader(
+        table=a_dummy_table,
+        rollout_count=1,
+        rollout_length=1,
+        size_key="batch_size",
+        data_group="a",
+    )
+
+    with pytest.raises(Exception, match="JointMemoryLoader"):
+        joint_loader = JointMemoryLoader([loader1, loader2]) # noqa

--- a/tests/test_memory_loading.py
+++ b/tests/test_memory_loading.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pytest
+
+from emote.memory.column import Column
+from emote.memory.fifo_strategy import FifoEjectionStrategy
+from emote.memory.memory import JointMemoryLoader, MemoryLoader
+from emote.memory.table import ArrayTable
+from emote.memory.uniform_strategy import UniformSampleStrategy
+
+
+@pytest.fixture
+def a_dummy_table():
+    tab = ArrayTable(
+        columns=[Column("state", (), np.float32), Column("action", (), np.float32)],
+        maxlen=1_000,
+        sampler=UniformSampleStrategy(),
+        ejector=FifoEjectionStrategy(),
+        length_key="action",
+        device="cpu",
+    )
+    tab.add_sequence(
+        0,
+        {
+            "state": [5.0, 6.0],
+            "action": [1.0],
+        },
+    )
+
+    return tab
+
+
+@pytest.fixture
+def another_dummy_table():
+    tab = ArrayTable(
+        columns=[Column("state", (), np.float32), Column("action", (), np.float32)],
+        maxlen=1_000,
+        sampler=UniformSampleStrategy(),
+        ejector=FifoEjectionStrategy(),
+        length_key="action",
+        device="cpu",
+    )
+    tab.add_sequence(
+        0,
+        {
+            "state": [5.0, 6.0],
+            "action": [1.0],
+        },
+    )
+
+    return tab
+
+
+def test_joint_memory_loader_no_datagroup(
+    a_dummy_table: ArrayTable, another_dummy_table: ArrayTable
+):
+    a_loader = MemoryLoader(
+        table=a_dummy_table,
+        rollout_count=1,
+        rollout_length=1,
+        size_key="batch_size",
+        data_group="a",
+    )
+    another_loader = MemoryLoader(
+        table=another_dummy_table,
+        rollout_count=1,
+        rollout_length=1,
+        size_key="batch_size",
+        data_group="another",
+    )
+
+    joint_loader = JointMemoryLoader(loaders=[a_loader, another_loader])
+
+    data = next(iter(joint_loader))
+    assert "a" in data and "another" in data, "JointMemoryLoader did not yield expected memory data"
+
+
+def test_joint_memory_loader_datagroup(a_dummy_table: ArrayTable, another_dummy_table: ArrayTable):
+    a_loader = MemoryLoader(
+        table=a_dummy_table,
+        rollout_count=1,
+        rollout_length=1,
+        size_key="batch_size",
+        data_group="a",
+    )
+    another_loader = MemoryLoader(
+        table=another_dummy_table,
+        rollout_count=1,
+        rollout_length=1,
+        size_key="batch_size",
+        data_group="another",
+    )
+
+    joint_loader = JointMemoryLoader(
+        loaders=[a_loader, another_loader], data_group="joint_datagroup"
+    )
+
+    encapsulated_data = next(iter(joint_loader))
+    data = encapsulated_data["joint_datagroup"]
+
+    assert (
+        "joint_datagroup" in encapsulated_data
+    ), "Expected joint dataloader to place data in its own datagroup, but it does not exist."
+    assert (
+        "a" in data and "another" in data
+    ), "Expected joint dataloader to actually place data in its datagroup, but it is empty."

--- a/tests/test_memory_loading.py
+++ b/tests/test_memory_loading.py
@@ -3,7 +3,7 @@ import pytest
 
 from emote.memory.column import Column
 from emote.memory.fifo_strategy import FifoEjectionStrategy
-from emote.memory.memory import JointMemoryLoader, MemoryLoader
+from emote.memory.memory import JointMemoryLoader, JointMemoryLoaderWithDataGroup, MemoryLoader
 from emote.memory.table import ArrayTable
 from emote.memory.uniform_strategy import UniformSampleStrategy
 
@@ -50,7 +50,7 @@ def another_dummy_table():
     return tab
 
 
-def test_joint_memory_loader_no_datagroup(
+def test_joint_memory_loader(
     a_dummy_table: ArrayTable, another_dummy_table: ArrayTable
 ):
     a_loader = MemoryLoader(
@@ -90,7 +90,7 @@ def test_joint_memory_loader_datagroup(a_dummy_table: ArrayTable, another_dummy_
         data_group="another",
     )
 
-    joint_loader = JointMemoryLoader(
+    joint_loader = JointMemoryLoaderWithDataGroup(
         loaders=[a_loader, another_loader], data_group="joint_datagroup"
     )
 

--- a/tests/test_memory_loading.py
+++ b/tests/test_memory_loading.py
@@ -120,4 +120,4 @@ def test_joint_memory_loader_nonunique_loaders_trigger_exception(a_dummy_table: 
     )
 
     with pytest.raises(Exception, match="JointMemoryLoader"):
-        joint_loader = JointMemoryLoader([loader1, loader2]) # noqa
+        joint_loader = JointMemoryLoader([loader1, loader2])  # noqa


### PR DESCRIPTION
This PR adds a `JointMemoryLoader` object that can sample data from multiple different `MemoryLoader`s. This is needed for a lot of imitation related training.