### PR TITLE
Fix wrong path in docs/getting_started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -5,12 +5,12 @@ In the `/experiments` folder, example runs can be found for different Gymnasium 
 For example, you can run the cartpole example using DQN with the following command:
 
 ```python
-pdm run python experiments/train_dqn_cartpole.py
+pdm run python experiments/gym/train_dqn_cartpole.py
 ```
 
 ![Alt Text](cart_pole.gif)
 
-This comes with a lot of predefined arguments, such as the learning rate, the amount of hidden layers, the batch size, etc. You can find all the arguments in the `experiments/train_dqn_cartpole.py` file.
+This comes with a lot of predefined arguments, such as the learning rate, the amount of hidden layers, the batch size, etc. You can find all the arguments in the `experiments/gym/train_dqn_cartpole.py` file.
 
 ## 📊 Tensorboard
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,6 @@
 # 🔥 Getting Started
 
-In the `/experiments` folder, example runs can be found for different Gymnasium environments.
+In the `/experiments/gym/` folder, example runs can be found for different Gymnasium environments.
 
 For example, you can run the cartpole example using DQN with the following command:
 


### PR DESCRIPTION
The documentation in [docs/getting_started.md](https://github.com/EmbarkStudios/emote/blob/main/docs/getting_started.md) contains a wrong path for the Gymnasium environments.

This PR updates `experiments/` to `experiments/gym/`.