### PR TITLE
Update AlphaLoss to support entropy schedules

### DIFF
--- a/emote/algorithms/sac.py
+++ b/emote/algorithms/sac.py
@@ -292,7 +292,7 @@ class AlphaLoss(LossCallback):
         with torch.no_grad():
             _, logp_pi = self.policy(**observation)
             entropy = -logp_pi
-            error = entropy - self.t_entropy.get_last_val()
+            error = entropy - self.t_entropy.value
         alpha_loss = torch.mean(self.ln_alpha * error.detach())
         assert alpha_loss.dim() == 0
         self.log_scalar("loss/alpha_loss", alpha_loss)
@@ -305,7 +305,7 @@ class AlphaLoss(LossCallback):
         self.ln_alpha = torch.clamp_max_(self.ln_alpha, self._max_ln_alpha)
         self.ln_alpha.requires_grad_(True)
         self.log_scalar("training/alpha_value", torch.exp(self.ln_alpha).item())
-        self.log_scalar("training/target_entropy", self.t_entropy.get_last_val())
+        self.log_scalar("training/target_entropy", self.t_entropy.value)
         self.t_entropy.step()
 
     def state_dict(self):

--- a/emote/algorithms/sac.py
+++ b/emote/algorithms/sac.py
@@ -4,7 +4,6 @@ import copy
 
 from typing import Any, Dict, Optional
 
-import numpy as np
 import torch
 
 from torch import nn, optim

--- a/emote/algorithms/sac.py
+++ b/emote/algorithms/sac.py
@@ -11,7 +11,6 @@ from torch import nn, optim
 from emote.callback import Callback
 from emote.callbacks.loss import LossCallback
 from emote.extra.schedules import ConstantSchedule, Schedule
-from emote.extra.schedules import ConstantSchedule, Schedule
 from emote.mixins.logging import LoggingMixin
 from emote.proxies import AgentProxy, GenericAgentProxy
 from emote.utils.deprecated import deprecated

--- a/emote/algorithms/sac.py
+++ b/emote/algorithms/sac.py
@@ -245,7 +245,7 @@ class AlphaLoss(LossCallback):
         probability given a state.
     :param ln_alpha (torch.tensor): The current weight for the entropy part of the
         soft Q.
-    :param  lr_schedule (torch.optim.lr_scheduler._LRSchedule): Learning rate schedule
+    :param  lr_schedule (torch.optim.lr_scheduler._LRSchedule | None): Learning rate schedule
         for the optimizer of alpha.
     :param opt (torch.optim.Optimizer): An optimizer for ln_alpha.
     :param n_actions (int): The dimension of the action space. Scales the target
@@ -255,7 +255,7 @@ class AlphaLoss(LossCallback):
     :param name (str): The name of the module. Used e.g. while logging.
     :param data_group (str): The name of the data group from which this Loss takes its
         data.
-    :param t_entropy (float | Schedule, optional): Value or schedule for the target entropy.
+    :param t_entropy (float | Schedule | None): Value or schedule for the target entropy.
     """
 
     def __init__(
@@ -264,13 +264,13 @@ class AlphaLoss(LossCallback):
         pi: nn.Module,
         ln_alpha: torch.tensor,
         opt: optim.Optimizer,
-        lr_schedule: Optional[optim.lr_scheduler._LRScheduler] = None,
+        lr_schedule: optim.lr_scheduler._LRScheduler | None = None,
         n_actions: int,
         max_grad_norm: float = 10.0,
         max_alpha: float = 0.2,
         name: str = "alpha",
         data_group: str = "default",
-        t_entropy: float | Schedule = None,
+        t_entropy: float | Schedule | None = None,
     ):
         super().__init__(
             name=name,

--- a/emote/algorithms/sac.py
+++ b/emote/algorithms/sac.py
@@ -284,8 +284,13 @@ class AlphaLoss(LossCallback):
         self._max_ln_alpha = torch.log(torch.tensor(max_alpha, device=ln_alpha.device))
         # TODO(singhblom) Check number of actions
         # self.t_entropy = -np.prod(self.env.action_space.shape).item()  # Value from rlkit from Harnouja
-        t_entropy = float(-n_actions) if t_entropy is None else t_entropy
-        self.t_entropy = ConstantSchedule(t_entropy) if isinstance(t_entropy, float) else t_entropy
+        t_entropy = -n_actions if t_entropy is None else t_entropy
+        if not isinstance(t_entropy, (int, float, Schedule)):
+            raise TypeError("t_entropy must be a number or an instance of Schedule")
+
+        self.t_entropy = (
+            t_entropy if isinstance(t_entropy, Schedule) else ConstantSchedule(t_entropy)
+        )
         self.ln_alpha = ln_alpha  # This is log(alpha)
 
     def loss(self, observation):


### PR DESCRIPTION
This PR adds support for entropy schedules in the AlphaLoss callback. Also I removed the multiplication term in the default target entropy value since it defaulted to a very small value (CC @AliGhadirzadeh) and now we have the option to set the target value directly instead of scaling the number of actions by changing `entropy_eps`.