### PR TITLE
Fix wrong `onnx.load_model` arguments

### DIFF
--- a/emote/extra/onnx_exporter.py
+++ b/emote/extra/onnx_exporter.py
@@ -206,7 +206,7 @@ class OnnxExporter(LoggingMixin, Callback):
                 )
 
                 f.seek(0)
-                model_proto = onnx.load_model(f, onnx.ModelProto)
+                model_proto = onnx.load_model(f)
 
             return model_proto
 


### PR DESCRIPTION
We called this with a second argument that got ignored in onnx 1.14.1, but with 1.15.0, this is not legal anymore. Removing the second argument should fix this. 