### PR TITLE
Update Github Workflows for Python3.10

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,9 +16,6 @@ concurrency:
 
 jobs:
   build-docs:
-    environment:
-        name: github-pages
-        url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PDM
         uses: pdm-project/setup-pdm@v3
         with:
-          python-version: 3.10.0
+          python-version: 3.10.4
           architecture: x64
           version: 2.10.1
           prerelease: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup PDM
         uses: pdm-project/setup-pdm@v3
         with:
-          python-version: 3.10.4
+          python-version: '3.10'
           architecture: x64
           version: 2.10.1
           prerelease: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,6 @@ name: Deploy static content to Pages
 on:
   push:
     branches: ["main", "luc/test31"]
-
   workflow_dispatch:
 
 permissions:
@@ -16,20 +15,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v1
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
-      - uses: pdm-project/setup-pdm@v3
-        name: Setup PDM
+      - name: Setup PDM
+        uses: pdm-project/setup-pdm@v3
         with:
           python-version: 3.10.0
           architecture: x64
@@ -42,20 +36,29 @@ jobs:
         run: pdm install --plugins && pdm install -d -G ci && pdm torch install cpu
       - name: Build docs
         run: cd docs && make deploy
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: doc-build
+          path: 'docs/_build/dirhtml'
 
-  deploy-and-upload:
+  deploy:
+    needs: build-docs
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Upload artifact
-        if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Download artifact
+        uses: actions/download-artifact@v2
         with:
-          # Upload entire repository
+          name: doc-build
           path: 'docs/_build/dirhtml'
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main'
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,10 @@
 name: Deploy static content to Pages
 
 on:
+  pull_request:  
+    branches: [main]
   push:
-    branches: ["main", "luc/test31"]
+    branches: ["main"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ concurrency:
 
 jobs:
   build-docs:
+    environment:
+        name: github-pages
+        url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,12 +43,12 @@ jobs:
       - name: Build docs
         run: cd docs && make deploy
       - name: Upload artifact
-        if: github.ref == 'refs/head/main'
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v1
         with:
           # Upload entire repository
           path: 'docs/_build/dirhtml'
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/head/main'
+        if: github.ref == 'refs/heads/main'
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,13 @@ jobs:
         run: pdm install --plugins && pdm install -d -G ci && pdm torch install cpu
       - name: Build docs
         run: cd docs && make deploy
+
+  deploy-and-upload:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Upload artifact
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Deploy static content to Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "luc/test31"]
 
   workflow_dispatch:
 
@@ -31,7 +31,7 @@ jobs:
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM
         with:
-          python-version: 3.10
+          python-version: 3.10.0
           architecture: x64
           version: 2.10.1
           prerelease: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,10 +43,12 @@ jobs:
       - name: Build docs
         run: cd docs && make deploy
       - name: Upload artifact
+        if: github.ref == 'refs/head/main'
         uses: actions/upload-pages-artifact@v1
         with:
           # Upload entire repository
           path: 'docs/_build/dirhtml'
       - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/head/main'
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Accept Repository Changes
+        run: |
+          sudo apt-get --allow-releaseinfo-change update
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v1
       - name: Setup PDM

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM
         with:
-          python-version: 3.10.4
+          python-version: '3.10'
           architecture: x64
           version: 2.10.1
           prerelease: true

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM
         with:
-          python-version: 3.10
+          python-version: 3.10.0
           architecture: x64
           version: 2.10.1
           prerelease: true

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM
         with:
-          python-version: 3.10.0
+          python-version: 3.10.4
           architecture: x64
           version: 2.10.1
           prerelease: true

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -3,6 +3,9 @@ name: Publish pre-release package
 on:
   schedule:
   - cron: "0 0 * * *"
+  push:
+    branches:
+      - luc/test31  
 
   workflow_dispatch:
 

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -3,9 +3,6 @@ name: Publish pre-release package
 on:
   schedule:
   - cron: "0 0 * * *"
-  push:
-    branches:
-      - luc/test31  
 
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - luc/test31  # Added this line
 
 jobs:
   create-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: pdm-project/setup-pdm@v3
       name: Setup PDM
       with:
-        python-version: 3.10
+        python-version: 3.10.0
         architecture: x64
         version: 2.10.1
         prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: pdm-project/setup-pdm@v3
       name: Setup PDM
       with:
-        python-version: 3.10.0
+        python-version: 3.10.4
         architecture: x64
         version: 2.10.1
         prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: pdm-project/setup-pdm@v3
       name: Setup PDM
       with:
-        python-version: 3.10.4
+        python-version: '3.10'
         architecture: x64
         version: 2.10.1
         prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - v*
+    branches:
+      - luc/test31  # Added this line
 
 jobs:
   create-release:


### PR DESCRIPTION
Since updating to python3.10, github actions failed as specifiying the python-version in the workflow files with only 3.10 got only parsed as 3.1. Setting this to 3.10.4 makes it find a proper build. 

This PR also separates the build-docs and deploy jobs, and runs the former whenever a PR is opened. 