### PR TITLE
adding JointMemoryLoader to the init

### DIFF
--- a/emote/memory/__init__.py
+++ b/emote/memory/__init__.py
@@ -4,12 +4,12 @@
 
 from .callbacks import MemoryImporterCallback
 from .memory import (
+    JointMemoryLoader,
     LoggingProxyWrapper,
     MemoryExporterProxyWrapper,
     MemoryLoader,
     MemoryWarmup,
     TableMemoryProxy,
-    JointMemoryLoader,
 )
 from .table import Table
 

--- a/emote/memory/__init__.py
+++ b/emote/memory/__init__.py
@@ -9,6 +9,7 @@ from .memory import (
     MemoryLoader,
     MemoryWarmup,
     TableMemoryProxy,
+    JointMemoryLoader,
 )
 from .table import Table
 
@@ -21,4 +22,5 @@ __all__ = [
     "MemoryImporterCallback",
     "LoggingProxyWrapper",
     "MemoryWarmup",
+    "JointMemoryLoader",
 ]


### PR DESCRIPTION
JointMemoryLoader is missing in the init file. 