### PR TITLE
Collect cum logs under their own heading

### DIFF
--- a/emote/callbacks/logging.py
+++ b/emote/callbacks/logging.py
@@ -53,7 +53,7 @@ class TensorboardLogger(Callback):
 
             for k, v in cb.windowed_scalar_cumulative.items():
                 k_split = k.split("/")
-                k_split[0] = k_split[0] + "_" + suffix
+                k_split[0] = f"cumulative/{k_split[0]}_{suffix}"
                 k = "/".join(k_split)
 
                 self._writer.add_scalar(f"{k}/cumulative", v, bp_step)

--- a/emote/callbacks/wb_logger.py
+++ b/emote/callbacks/wb_logger.py
@@ -63,7 +63,7 @@ class WBLogger(Callback):
 
             for k, v in cb.windowed_scalar_cumulative.items():
                 k_split = k.split("/")
-                k_split[0] = k_split[0] + "_" + suffix
+                k_split[0] = f"cumulative/{k_split[0]}_{suffix}"
                 k = "/".join(k_split)
 
                 log_dict[f"{k}/cumulative"] = v


### PR DESCRIPTION
We rarely need the cumulative logs, but when they are needed it's really good to have. I have therefore hidden them all under a common `cumulative/` heading in tb.